### PR TITLE
create super admin role

### DIFF
--- a/.ai/memory/architecture.md
+++ b/.ai/memory/architecture.md
@@ -1,0 +1,91 @@
+# Hellfire Gatekeeper — Architecture & Philosophy
+
+This document is the source of truth for local AI architecture review.
+Judge code against these rules. Prefer project conventions over generic Go advice.
+
+## Purpose
+
+Backend API for a multi-tenant bakery management system (products, orders, auth, images, subscriptions).
+
+## Layering (Clean Architecture)
+
+Allowed dependency flow only:
+
+```
+handlers → services → repository
+```
+
+- `internal/handlers/` — HTTP adapters: parse request, validate, call services, map errors to HTTP.
+- `internal/services/` — business logic and orchestration.
+- `internal/repository/` — data access (SQL). No business rules that belong in services.
+- `internal/middleware/` — auth, tenant, subscription, rate limit.
+- `internal/handlers/validators/` — request/input validation.
+- `model/` — domain/data models (no HTTP, no SQL drivers).
+- `cmd/api/` — wiring / composition root only.
+- `migrations/` — schema changes via golang-migrate.
+- `tests/` — integration tests (testcontainers + real PostgreSQL).
+
+### Forbidden
+
+- Handlers calling repositories directly (bypass services).
+- Services importing handlers or middleware.
+- Repositories importing services or handlers.
+- Cross-layer shortcuts or circular dependencies.
+- Creating concrete external clients inside handlers/services (use interfaces + constructor injection).
+
+## Dependency injection
+
+- Inject dependencies via constructors.
+- External deps (DB, email, storage, clocks) behind interfaces.
+- Never `NewX()` hidden inside business methods when it should be injected.
+
+## Errors
+
+- Prefer domain/sentinel errors from `internal/errors`.
+- Wrap with context: `fmt.Errorf("failed to create order: %w", err)`.
+- Handlers must map known errors to the correct HTTP status (e.g. HTTPError / BadRequest helpers).
+- Do not leak internal/DB details in HTTP responses.
+
+## Logging
+
+- Use structured logger (`zerolog` via `internal/logger`), not `fmt.Printf` / `log.Println` for app logs.
+- Include relevant context: `user_id`, `tenant_id`, `order_id`, operation name.
+- Levels: debug, info, warn, error.
+- Never log secrets, passwords, tokens, or raw credentials.
+
+## Security
+
+- Validate all user input (validators / handler validation).
+- Protected routes must use auth middleware (JWT).
+- Passwords: bcrypt only; never store plaintext.
+- No hardcoded secrets; use env vars.
+- Respect tenant isolation — do not cross tenant boundaries in queries or auth checks.
+
+## Database
+
+- Schema changes only through migrations.
+- Use transactions for multi-step writes.
+- Keep history tables where the domain already does (`products_history`, `orders_history`, etc.).
+- DB naming: `snake_case`; descriptive prefixes (`id_`, `created_on`, `modified_on`).
+- Avoid N+1 queries; prefer explicit joins/batching when listing related data.
+
+## Testing
+
+- TDD mindset for new behavior: tests should cover the change.
+- Unit tests for repositories with `sqlmock`.
+- Integration tests with testcontainers for full flows.
+- Naming: `Test[Struct]_[Method]_[Scenario]`.
+- Use `testify/assert` or `testify/require`.
+- Cover happy path, edge cases, and error paths for new logic.
+
+## Style
+
+- Exported: PascalCase. Unexported: camelCase.
+- Code, comments, and public docs in English.
+- Files: `[domain].go`, `[domain]_test.go`.
+- Keep functions small and single-purpose.
+
+## Pagination / lists
+
+- List endpoints follow existing cursor/keyset pagination patterns (`limit`, `cursor`, `next_cursor`).
+- Do not invent offset pagination for new list APIs unless explicitly required and documented.

--- a/.ai/memory/checklist.md
+++ b/.ai/memory/checklist.md
@@ -1,0 +1,41 @@
+# Architecture review checklist
+
+Use this as a fast scan against the diff. Flag only issues supported by the guidelines.
+
+## Layers & DI
+
+- [ ] No handler → repository bypass
+- [ ] No upward imports (repo/service → handler)
+- [ ] External deps behind interfaces + constructor injection
+- [ ] No `NewConcrete()` inside business logic that should be injected
+
+## Handlers & HTTP
+
+- [ ] Input validated before business logic
+- [ ] Protected routes still guarded by auth/tenant/subscription middleware as appropriate
+- [ ] Errors mapped to correct HTTP status; no raw internal errors to clients
+
+## Errors & logging
+
+- [ ] Uses `internal/errors` / wrapping with `%w` where appropriate
+- [ ] Structured logging (not `fmt.Printf`)
+- [ ] No secrets/tokens/passwords in logs
+
+## Data & migrations
+
+- [ ] Schema changes include migrations
+- [ ] Multi-write paths use transactions when needed
+- [ ] Tenant-scoped queries preserve isolation
+- [ ] History tables updated when the existing domain pattern requires it
+
+## Tests
+
+- [ ] New behavior has unit and/or integration tests
+- [ ] Test names follow `Test[Struct]_[Method]_[Scenario]`
+- [ ] Error and edge paths covered for critical logic
+
+## Security & config
+
+- [ ] No hardcoded secrets
+- [ ] Passwords hashed with bcrypt
+- [ ] User-controlled input not trusted without validation

--- a/.ai/prompts/reviewer.md
+++ b/.ai/prompts/reviewer.md
@@ -1,6 +1,11 @@
 You are an architecture compliance reviewer for a Go backend.
 Judge the git diff ONLY against the provided project guidelines.
-Do not explain or summarize the code.
-Do not write docs, tutorials, or usage guides.
-Reply in plain markdown only. Never wrap the answer in JSON or code fences.
-Output MUST start with the line: ## Verdict
+
+Hard rules:
+- Cite ONLY file paths that appear in the "ALLOWED PATHS" list (paths from the git diff).
+- Never invent files, packages, CI tools, or issues not evidenced by the diff.
+- If the diff has no guideline violations, Findings must be exactly `- none` and Cursor action list must be exactly `none`.
+- Do not explain or summarize the code.
+- Do not write docs, tutorials, or usage guides.
+- Reply in plain markdown only. Never wrap the answer in JSON or code fences.
+- Output MUST start with the line: ## Verdict

--- a/.ai/prompts/reviewer.md
+++ b/.ai/prompts/reviewer.md
@@ -1,0 +1,6 @@
+You are an architecture compliance reviewer for a Go backend.
+Judge the git diff ONLY against the provided project guidelines.
+Do not explain or summarize the code.
+Do not write docs, tutorials, or usage guides.
+Reply in plain markdown only. Never wrap the answer in JSON or code fences.
+Output MUST start with the line: ## Verdict

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ go.work.sum
 
 markdowns/
 .gopath/
+
+# Local AI review outputs (keep the folder)
+.ai/reviews/*.md
+!.ai/reviews/.gitkeep

--- a/cmd/ai/diffpaths.go
+++ b/cmd/ai/diffpaths.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"sort"
+	"strings"
+)
+
+// extractDiffPaths returns unique repo-relative paths mentioned in a unified diff.
+func extractDiffPaths(diff string) []string {
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(diff, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			// diff --git a/path b/path
+			rest := strings.TrimPrefix(line, "diff --git ")
+			parts := strings.Fields(rest)
+			for _, p := range parts {
+				if path, ok := stripDiffPathPrefix(p); ok {
+					seen[path] = struct{}{}
+				}
+			}
+		case strings.HasPrefix(line, "+++ "), strings.HasPrefix(line, "--- "):
+			field := strings.Fields(line)
+			if len(field) < 2 {
+				continue
+			}
+			raw := field[1]
+			if raw == "/dev/null" || raw == "NUL" {
+				continue
+			}
+			if path, ok := stripDiffPathPrefix(raw); ok {
+				seen[path] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stripDiffPathPrefix(p string) (string, bool) {
+	p = filepathToSlash(strings.TrimSpace(p))
+	if p == "" || p == "/dev/null" || p == "NUL" {
+		return "", false
+	}
+	if strings.HasPrefix(p, "a/") || strings.HasPrefix(p, "b/") {
+		p = p[2:]
+	}
+	p = strings.TrimPrefix(p, "./")
+	if p == "" {
+		return "", false
+	}
+	return p, true
+}

--- a/cmd/ai/git.go
+++ b/cmd/ai/git.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func getGitDiff(root string, staged bool, base string) (diff string, label string, err error) {
+	var args []string
+	switch {
+	case staged:
+		args = []string{"diff", "--staged"}
+		label = "staged"
+	case base != "":
+		args = []string{"diff", base + "...HEAD"}
+		label = base + "...HEAD"
+	default:
+		args = []string{"diff", "HEAD"}
+		label = "working tree vs HEAD"
+	}
+
+	out, err := runGit(root, args...)
+	if err != nil {
+		return "", label, err
+	}
+
+	// Also include untracked new files when reviewing the working tree,
+	// otherwise brand-new files never appear in `git diff HEAD`.
+	if !staged && base == "" {
+		untracked, uerr := untrackedFileDiffs(root)
+		if uerr != nil {
+			return "", label, uerr
+		}
+		if untracked != "" {
+			if out != "" {
+				out += "\n"
+			}
+			out += untracked
+			label += " + untracked"
+		}
+	}
+
+	return strings.TrimSpace(out), label, nil
+}
+
+func untrackedFileDiffs(root string) (string, error) {
+	list, err := runGit(root, "ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return "", err
+	}
+	files := splitGitLines(list)
+	if len(files) == 0 {
+		return "", nil
+	}
+
+	var b strings.Builder
+	for _, f := range files {
+		// Skip bulky/generated paths; review should stay focused on source.
+		if shouldSkipUntracked(f) {
+			continue
+		}
+		diff, err := syntheticNewFileDiff(root, f)
+		if err != nil {
+			return "", fmt.Errorf("diff untracked %s: %w", f, err)
+		}
+		if strings.TrimSpace(diff) != "" {
+			b.WriteString(diff)
+			if !strings.HasSuffix(diff, "\n") {
+				b.WriteByte('\n')
+			}
+		}
+	}
+	return b.String(), nil
+}
+
+func splitGitLines(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// syntheticNewFileDiff builds a unified diff for an untracked file without
+// relying on OS-specific /dev/null or NUL paths.
+func syntheticNewFileDiff(root, rel string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		return "", err
+	}
+	// Skip obviously binary/large blobs.
+	if len(data) > 200_000 || bytes.IndexByte(data, 0) >= 0 {
+		return "", nil
+	}
+
+	slash := filepathToSlash(rel)
+	var b strings.Builder
+	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", slash, slash)
+	b.WriteString("new file mode 100644\n")
+	b.WriteString("--- /dev/null\n")
+	fmt.Fprintf(&b, "+++ b/%s\n", slash)
+
+	content := string(data)
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	// Split keeps a trailing empty element if file ends with newline; trim that visual noise.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	fmt.Fprintf(&b, "@@ -0,0 +1,%d @@\n", len(lines))
+	for _, line := range lines {
+		b.WriteString("+")
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+func shouldSkipUntracked(path string) bool {
+	p := strings.ToLower(filepathToSlash(path))
+	switch {
+	case strings.HasPrefix(p, ".ai/reviews/"):
+		return true
+	case strings.HasSuffix(p, ".exe"):
+		return true
+	case strings.HasSuffix(p, ".png"), strings.HasSuffix(p, ".jpg"), strings.HasSuffix(p, ".jpeg"), strings.HasSuffix(p, ".gif"), strings.HasSuffix(p, ".webp"):
+		return true
+	case strings.HasPrefix(p, "uploads/"), strings.HasPrefix(p, "volumes/"), strings.HasPrefix(p, ".gopath/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func filepathToSlash(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
+}
+
+func runGit(root string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	out := stdout.String()
+	if err != nil {
+		// git diff --no-index returns exit code 1 when there is a diff.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 && out != "" {
+			return out, nil
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return out, fmt.Errorf("git %s: %s", strings.Join(args, " "), msg)
+	}
+	return out, nil
+}

--- a/cmd/ai/git.go
+++ b/cmd/ai/git.go
@@ -16,8 +16,15 @@ func getGitDiff(root string, staged bool, base string) (diff string, label strin
 		args = []string{"diff", "--staged"}
 		label = "staged"
 	case base != "":
-		args = []string{"diff", base + "...HEAD"}
-		label = base + "...HEAD"
+		resolved, rerr := resolveBaseRef(root, base)
+		if rerr != nil {
+			return "", "", rerr
+		}
+		if resolved != base {
+			fmt.Fprintf(os.Stderr, "base: %q not found; using %q\n", base, resolved)
+		}
+		args = []string{"diff", resolved + "...HEAD"}
+		label = resolved + "...HEAD"
 	default:
 		args = []string{"diff", "HEAD"}
 		label = "working tree vs HEAD"
@@ -45,6 +52,72 @@ func getGitDiff(root string, staged bool, base string) (diff string, label strin
 	}
 
 	return strings.TrimSpace(out), label, nil
+}
+
+// resolveBaseRef maps -base values to an existing git revision.
+// Accepts main/master interchangeably and falls back to origin/<name>
+// or the remote default branch (origin/HEAD).
+func resolveBaseRef(root, base string) (string, error) {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return "", fmt.Errorf("empty base ref")
+	}
+
+	for _, candidate := range baseRefCandidates(base) {
+		if _, err := runGit(root, "rev-parse", "--verify", "--quiet", candidate+"^{commit}"); err == nil {
+			return candidate, nil
+		}
+	}
+
+	if sym, err := runGit(root, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"); err == nil {
+		sym = strings.TrimSpace(sym)
+		if strings.HasPrefix(sym, "refs/remotes/") {
+			return strings.TrimPrefix(sym, "refs/remotes/"), nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"unknown base ref %q (tried: %s). Tip: this repo uses master as the default branch",
+		base,
+		strings.Join(baseRefCandidates(base), ", "),
+	)
+}
+
+func baseRefCandidates(base string) []string {
+	base = strings.TrimSpace(base)
+	var out []string
+	add := func(s string) {
+		for _, existing := range out {
+			if existing == s {
+				return
+			}
+		}
+		out = append(out, s)
+	}
+
+	add(base)
+	if !strings.HasPrefix(base, "origin/") {
+		add("origin/" + base)
+	}
+
+	switch base {
+	case "main":
+		add("master")
+		add("origin/master")
+	case "master":
+		add("main")
+		add("origin/main")
+	case "origin/main":
+		add("master")
+		add("origin/master")
+		add("main")
+	case "origin/master":
+		add("main")
+		add("origin/main")
+		add("master")
+	}
+
+	return out
 }
 
 func untrackedFileDiffs(root string) (string, error) {

--- a/cmd/ai/git_test.go
+++ b/cmd/ai/git_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseRefCandidates_MainFallsBackToMaster(t *testing.T) {
+	assert.Equal(t, []string{"main", "origin/main", "master", "origin/master"}, baseRefCandidates("main"))
+}
+
+func TestBaseRefCandidates_MasterFallsBackToMain(t *testing.T) {
+	assert.Equal(t, []string{"master", "origin/master", "main", "origin/main"}, baseRefCandidates("master"))
+}
+
+func TestBaseRefCandidates_FeatureBranch(t *testing.T) {
+	assert.Equal(t, []string{"create-super-admin", "origin/create-super-admin"}, baseRefCandidates("create-super-admin"))
+}

--- a/cmd/ai/main.go
+++ b/cmd/ai/main.go
@@ -1,0 +1,164 @@
+// Command ai runs a local architecture review via Ollama (Qwen).
+//
+// Prototype usage:
+//
+//	go run ./cmd/ai review
+//	go run ./cmd/ai review -staged
+//	go run ./cmd/ai review -base main
+//	go run ./cmd/ai review -dry-run
+//	go run ./cmd/ai review -save
+//
+// Env overrides: OLLAMA_HOST (default http://localhost:11434), OLLAMA_MODEL (default qwen3:8b).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "review":
+		if err := runReview(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	case "help", "-h", "--help":
+		printUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", os.Args[1])
+		printUsage()
+		os.Exit(2)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `ai — local architecture review with Ollama
+
+Usage:
+  go run ./cmd/ai review [flags]
+
+Flags:
+  -staged          review staged changes only (git diff --staged)
+  -base string     review merge-base diff against ref (e.g. main)
+  -model string    Ollama model (default: OLLAMA_MODEL or qwen3:8b)
+  -host string     Ollama host (default: OLLAMA_HOST or http://localhost:11434)
+  -dry-run         print assembled prompt; do not call Ollama
+  -save            write review under .ai/reviews/
+
+Examples:
+  go run ./cmd/ai review
+  go run ./cmd/ai review -staged -save
+  go run ./cmd/ai review -base main -model qwen2.5-coder:7b
+`)
+}
+
+func runReview(args []string) error {
+	fs := flag.NewFlagSet("review", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	staged := fs.Bool("staged", false, "use staged diff")
+	base := fs.String("base", "", "diff against this git ref")
+	model := fs.String("model", envOr("OLLAMA_MODEL", "qwen3:8b"), "Ollama model name")
+	host := fs.String("host", envOr("OLLAMA_HOST", "http://localhost:11434"), "Ollama base URL")
+	dryRun := fs.Bool("dry-run", false, "print prompt only")
+	save := fs.Bool("save", false, "save review to .ai/reviews")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *staged && *base != "" {
+		return fmt.Errorf("flags -staged and -base are mutually exclusive")
+	}
+
+	root, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+
+	diff, diffLabel, err := getGitDiff(root, *staged, *base)
+	if err != nil {
+		return err
+	}
+	if diff == "" {
+		fmt.Println("No changes to review (empty diff).")
+		return nil
+	}
+
+	prompt, err := buildReviewPrompt(root, diff)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "diff: %s (%d bytes)\n", diffLabel, len(diff))
+	fmt.Fprintf(os.Stderr, "model: %s @ %s\n", *model, *host)
+
+	if *dryRun {
+		fmt.Println(prompt.combined())
+		return nil
+	}
+
+	review, err := callOllama(*host, *model, prompt)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(review)
+
+	if *save {
+		path, err := saveReview(root, review)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "saved: %s\n", path)
+	}
+	return nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func findRepoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s", wd)
+		}
+		dir = parent
+	}
+}
+
+func saveReview(root, review string) (string, error) {
+	dir := filepath.Join(root, ".ai", "reviews")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("review-%s.md", time.Now().Format("20060102-150405"))
+	path := filepath.Join(dir, name)
+	content := fmt.Sprintf("# Architecture review\n\nGenerated: %s\n\n%s\n",
+		time.Now().Format(time.RFC3339), review)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/cmd/ai/main.go
+++ b/cmd/ai/main.go
@@ -111,6 +111,13 @@ func runReview(args []string) error {
 		return err
 	}
 
+	allowed := extractDiffPaths(diff)
+	cleaned, dropped := sanitizeReview(review, allowed)
+	if dropped > 0 {
+		fmt.Fprintf(os.Stderr, "sanitize: dropped %d finding(s) citing paths outside the diff\n", dropped)
+		review = cleaned
+	}
+
 	fmt.Println(review)
 
 	if *save {

--- a/cmd/ai/ollama.go
+++ b/cmd/ai/ollama.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type ollamaChatRequest struct {
+	Model    string          `json:"model"`
+	Stream   bool            `json:"stream"`
+	Messages []ollamaMessage `json:"messages"`
+	Options  map[string]any  `json:"options,omitempty"`
+}
+
+type ollamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ollamaChatResponse struct {
+	Message ollamaMessage `json:"message"`
+	Error   string        `json:"error,omitempty"`
+}
+
+func callOllama(host, model string, prompt reviewPrompt) (string, error) {
+	host = strings.TrimRight(host, "/")
+	url := host + "/api/chat"
+
+	body, err := json.Marshal(ollamaChatRequest{
+		Model:  model,
+		Stream: false,
+		Messages: []ollamaMessage{
+			{Role: "system", Content: prompt.System},
+			{Role: "user", Content: prompt.User},
+		},
+		Options: map[string]any{
+			"temperature": 0.1,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{Timeout: 10 * time.Minute}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("ollama request failed (is Ollama running at %s?): %w", host, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("ollama HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+
+	var parsed ollamaChatResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", fmt.Errorf("decode ollama response: %w", err)
+	}
+	if parsed.Error != "" {
+		return "", fmt.Errorf("ollama: %s", parsed.Error)
+	}
+	content := strings.TrimSpace(parsed.Message.Content)
+	if content == "" {
+		return "", fmt.Errorf("ollama returned empty content")
+	}
+	return normalizeReviewOutput(content), nil
+}
+
+// normalizeReviewOutput unwraps accidental JSON / fence wrappers so the
+// saved review is readable markdown.
+func normalizeReviewOutput(content string) string {
+	content = strings.TrimSpace(content)
+
+	if strings.HasPrefix(content, "```") {
+		content = strings.TrimPrefix(content, "```")
+		content = strings.TrimSpace(content)
+		if nl := strings.IndexByte(content, '\n'); nl >= 0 {
+			lang := strings.TrimSpace(content[:nl])
+			if lang == "json" || lang == "markdown" || lang == "md" || lang == "" {
+				content = content[nl+1:]
+			}
+		}
+		content = strings.TrimSpace(content)
+		content = strings.TrimSuffix(content, "```")
+		content = strings.TrimSpace(content)
+	}
+
+	if strings.HasPrefix(content, "{") {
+		var wrap struct {
+			Response string `json:"response"`
+			Content  string `json:"content"`
+			Review   string `json:"review"`
+		}
+		if err := json.Unmarshal([]byte(content), &wrap); err == nil {
+			for _, candidate := range []string{wrap.Response, wrap.Content, wrap.Review} {
+				candidate = strings.TrimSpace(candidate)
+				if candidate != "" {
+					// JSON may store markdown with escaped newlines; Unmarshal already unescapes.
+					return strings.TrimSpace(candidate)
+				}
+			}
+		}
+	}
+
+	return content
+}

--- a/cmd/ai/prompt.go
+++ b/cmd/ai/prompt.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type reviewPrompt struct {
+	System string
+	User   string
+}
+
+func buildReviewPrompt(root, diff string) (reviewPrompt, error) {
+	reviewer, err := readAIFile(root, "prompts", "reviewer.md")
+	if err != nil {
+		return reviewPrompt{}, err
+	}
+	architecture, err := readAIFile(root, "memory", "architecture.md")
+	if err != nil {
+		return reviewPrompt{}, err
+	}
+	checklist, err := readAIFile(root, "memory", "checklist.md")
+	if err != nil {
+		return reviewPrompt{}, err
+	}
+
+	var user strings.Builder
+	user.WriteString("# PROJECT GUIDELINES\n\n")
+	user.WriteString(strings.TrimSpace(architecture))
+	user.WriteString("\n\n")
+	user.WriteString(strings.TrimSpace(checklist))
+	user.WriteString("\n\n")
+	user.WriteString("# GIT DIFF TO REVIEW\n\n")
+	user.WriteString("```diff\n")
+	user.WriteString(diff)
+	if !strings.HasSuffix(diff, "\n") {
+		user.WriteByte('\n')
+	}
+	user.WriteString("```\n\n")
+	user.WriteString("# TASK\n")
+	user.WriteString("Review the git diff against the guidelines above.\n\n")
+	user.WriteString("Severity:\n")
+	user.WriteString("- BLOCK = clear architecture/security/data violation\n")
+	user.WriteString("- WARN = likely issue or missing tests/migrations\n")
+	user.WriteString("- NOTE = minor nit\n\n")
+	user.WriteString("Write ONLY this plain markdown template.\n")
+	user.WriteString("Do NOT use JSON. Do NOT wrap the answer in code fences.\n\n")
+	user.WriteString("## Verdict\n")
+	user.WriteString("OK | WARN | BLOCK\n\n")
+	user.WriteString("## Summary\n")
+	user.WriteString("One or two sentences on guideline compliance.\n\n")
+	user.WriteString("## Findings\n")
+	user.WriteString("- [SEVERITY] path — issue — guideline — fix\n")
+	user.WriteString("or\n")
+	user.WriteString("- none\n\n")
+	user.WriteString("## Cursor action list\n")
+	user.WriteString("1. ...\n")
+	user.WriteString("or\n")
+	user.WriteString("none\n\n")
+	user.WriteString("Begin now with ## Verdict\n")
+
+	return reviewPrompt{
+		System: strings.TrimSpace(reviewer),
+		User:   user.String(),
+	}, nil
+}
+
+func (p reviewPrompt) combined() string {
+	return p.System + "\n\n" + p.User
+}
+
+func readAIFile(root string, parts ...string) (string, error) {
+	pathParts := append([]string{root, ".ai"}, parts...)
+	path := filepath.Join(pathParts...)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	return string(data), nil
+}

--- a/cmd/ai/prompt.go
+++ b/cmd/ai/prompt.go
@@ -26,12 +26,27 @@ func buildReviewPrompt(root, diff string) (reviewPrompt, error) {
 		return reviewPrompt{}, err
 	}
 
+	allowed := extractDiffPaths(diff)
+
 	var user strings.Builder
 	user.WriteString("# PROJECT GUIDELINES\n\n")
 	user.WriteString(strings.TrimSpace(architecture))
 	user.WriteString("\n\n")
 	user.WriteString(strings.TrimSpace(checklist))
 	user.WriteString("\n\n")
+	user.WriteString("# ALLOWED PATHS\n\n")
+	user.WriteString("You may cite ONLY these paths (from the git diff).\n")
+	user.WriteString("If a finding is not about one of these paths, do not report it.\n\n")
+	if len(allowed) == 0 {
+		user.WriteString("- (none extracted — report Findings as `- none`)\n")
+	} else {
+		for _, p := range allowed {
+			user.WriteString("- ")
+			user.WriteString(p)
+			user.WriteByte('\n')
+		}
+	}
+	user.WriteString("\n")
 	user.WriteString("# GIT DIFF TO REVIEW\n\n")
 	user.WriteString("```diff\n")
 	user.WriteString(diff)
@@ -40,7 +55,9 @@ func buildReviewPrompt(root, diff string) (reviewPrompt, error) {
 	}
 	user.WriteString("```\n\n")
 	user.WriteString("# TASK\n")
-	user.WriteString("Review the git diff against the guidelines above.\n\n")
+	user.WriteString("Review the git diff against the guidelines above.\n")
+	user.WriteString("Only flag issues with clear evidence in the diff.\n")
+	user.WriteString("Do not invent files, tools, or generic security TODOs.\n\n")
 	user.WriteString("Severity:\n")
 	user.WriteString("- BLOCK = clear architecture/security/data violation\n")
 	user.WriteString("- WARN = likely issue or missing tests/migrations\n")
@@ -56,7 +73,7 @@ func buildReviewPrompt(root, diff string) (reviewPrompt, error) {
 	user.WriteString("or\n")
 	user.WriteString("- none\n\n")
 	user.WriteString("## Cursor action list\n")
-	user.WriteString("1. ...\n")
+	user.WriteString("1. Concrete fix for a finding above (must reference an ALLOWED PATH)\n")
 	user.WriteString("or\n")
 	user.WriteString("none\n\n")
 	user.WriteString("Begin now with ## Verdict\n")

--- a/cmd/ai/sanitize.go
+++ b/cmd/ai/sanitize.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Path ends at whitespace or a dash separator (ASCII/Unicode) used in the template.
+var findingLineRe = regexp.MustCompile(`(?i)^-\s*\[(BLOCK|WARN|NOTE)\]\s+([^\s—]+)`)
+
+// sanitizeReview drops findings that cite paths outside the diff allowlist.
+// If nothing valid remains, Findings become "- none", action list "none", and Verdict "OK".
+// Returns the cleaned review and how many finding lines were dropped.
+func sanitizeReview(review string, allowedPaths []string) (string, int) {
+	original := review
+	review = strings.TrimSpace(review)
+	if review == "" {
+		return original, 0
+	}
+
+	allowed := make(map[string]struct{}, len(allowedPaths))
+	for _, p := range allowedPaths {
+		p = filepathToSlash(strings.TrimSpace(p))
+		if p != "" {
+			allowed[p] = struct{}{}
+		}
+	}
+
+	sections := splitMarkdownSections(review)
+	findingsIdx := -1
+	actionsIdx := -1
+	verdictIdx := -1
+	for i, s := range sections {
+		switch strings.ToLower(strings.TrimSpace(s.Title)) {
+		case "findings":
+			findingsIdx = i
+		case "cursor action list":
+			actionsIdx = i
+		case "verdict":
+			verdictIdx = i
+		}
+	}
+	if findingsIdx < 0 {
+		return original, 0
+	}
+
+	kept, dropped := filterFindingLines(sections[findingsIdx].Body, allowed)
+	if dropped == 0 {
+		return original, 0
+	}
+
+	if len(kept) == 0 {
+		sections[findingsIdx].Body = "- none\n"
+		if actionsIdx >= 0 {
+			sections[actionsIdx].Body = "none\n"
+		}
+		if verdictIdx >= 0 {
+			sections[verdictIdx].Body = "OK\n"
+		}
+	} else {
+		sections[findingsIdx].Body = strings.Join(kept, "\n") + "\n"
+		if verdictIdx >= 0 {
+			sections[verdictIdx].Body = verdictFromFindings(kept) + "\n"
+		}
+	}
+
+	return joinMarkdownSections(sections), dropped
+}
+
+func filterFindingLines(body string, allowed map[string]struct{}) (kept []string, dropped int) {
+	for _, line := range strings.Split(body, "\n") {
+		trim := strings.TrimSpace(line)
+		if trim == "" {
+			continue
+		}
+		if strings.EqualFold(trim, "- none") || strings.EqualFold(trim, "none") {
+			kept = append(kept, trim)
+			continue
+		}
+		m := findingLineRe.FindStringSubmatch(trim)
+		if m == nil {
+			// Preserve non-finding lines under Findings (rare).
+			kept = append(kept, trim)
+			continue
+		}
+		path := filepathToSlash(strings.Trim(m[2], "`\"'"))
+		path = strings.TrimPrefix(path, "./")
+		if pathAllowed(path, allowed) {
+			kept = append(kept, trim)
+			continue
+		}
+		dropped++
+	}
+	// If we only kept non-finding junk after dropping all real findings, treat as empty.
+	if dropped > 0 && !hasFindingOrNone(kept) {
+		return nil, dropped
+	}
+	return kept, dropped
+}
+
+func hasFindingOrNone(lines []string) bool {
+	for _, line := range lines {
+		if strings.EqualFold(line, "- none") || strings.EqualFold(line, "none") {
+			return true
+		}
+		if findingLineRe.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathAllowed(path string, allowed map[string]struct{}) bool {
+	if _, ok := allowed[path]; ok {
+		return true
+	}
+	// Allow basename-only citations when uniquely resolvable in the allowlist.
+	if !strings.Contains(path, "/") {
+		var matches int
+		for a := range allowed {
+			if strings.HasSuffix(a, "/"+path) || a == path {
+				matches++
+			}
+		}
+		return matches == 1
+	}
+	return false
+}
+
+func verdictFromFindings(lines []string) string {
+	verdict := "OK"
+	for _, line := range lines {
+		m := findingLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		switch strings.ToUpper(m[1]) {
+		case "BLOCK":
+			return "BLOCK"
+		case "WARN":
+			verdict = "WARN"
+		}
+	}
+	return verdict
+}
+
+type mdSection struct {
+	Title string // empty for preamble before first heading
+	Body  string
+}
+
+func splitMarkdownSections(doc string) []mdSection {
+	lines := strings.Split(doc, "\n")
+	var sections []mdSection
+	cur := mdSection{}
+	var body []string
+
+	flush := func() {
+		cur.Body = strings.Join(body, "\n")
+		if cur.Title != "" || strings.TrimSpace(cur.Body) != "" {
+			sections = append(sections, cur)
+		}
+		body = nil
+	}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			flush()
+			cur = mdSection{Title: strings.TrimSpace(strings.TrimPrefix(line, "## "))}
+			continue
+		}
+		body = append(body, line)
+	}
+	flush()
+	return sections
+}
+
+func joinMarkdownSections(sections []mdSection) string {
+	var b strings.Builder
+	for i, s := range sections {
+		if s.Title != "" {
+			if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n\n") {
+				if !strings.HasSuffix(b.String(), "\n") {
+					b.WriteByte('\n')
+				}
+				b.WriteByte('\n')
+			}
+			fmt.Fprintf(&b, "## %s\n", s.Title)
+		}
+		body := s.Body
+		if !strings.HasSuffix(body, "\n") && body != "" {
+			body += "\n"
+		}
+		b.WriteString(body)
+		if i < len(sections)-1 && !strings.HasSuffix(b.String(), "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}

--- a/cmd/ai/sanitize.go
+++ b/cmd/ai/sanitize.go
@@ -11,6 +11,7 @@ var findingLineRe = regexp.MustCompile(`(?i)^-\s*\[(BLOCK|WARN|NOTE)\]\s+([^\sâ€
 
 // sanitizeReview drops findings that cite paths outside the diff allowlist.
 // If nothing valid remains, Findings become "- none", action list "none", and Verdict "OK".
+// When some findings remain, the action list is filtered to entries that mention an allowed path.
 // Returns the cleaned review and how many finding lines were dropped.
 func sanitizeReview(review string, allowedPaths []string) (string, int) {
 	original := review
@@ -62,6 +63,9 @@ func sanitizeReview(review string, allowedPaths []string) (string, int) {
 		sections[findingsIdx].Body = strings.Join(kept, "\n") + "\n"
 		if verdictIdx >= 0 {
 			sections[verdictIdx].Body = verdictFromFindings(kept) + "\n"
+		}
+		if actionsIdx >= 0 {
+			sections[actionsIdx].Body = filterActionLines(sections[actionsIdx].Body, allowed)
 		}
 	}
 
@@ -143,6 +147,63 @@ func verdictFromFindings(lines []string) string {
 		}
 	}
 	return verdict
+}
+
+// filterActionLines keeps action items that mention an allowed path, renumbers them,
+// and returns "none" when nothing valid remains.
+func filterActionLines(body string, allowed map[string]struct{}) string {
+	var kept []string
+	for _, line := range strings.Split(body, "\n") {
+		trim := strings.TrimSpace(line)
+		if trim == "" || strings.EqualFold(trim, "none") {
+			continue
+		}
+		if actionMentionsAllowedPath(trim, allowed) {
+			kept = append(kept, trim)
+		}
+	}
+	if len(kept) == 0 {
+		return "none\n"
+	}
+	out := make([]string, 0, len(kept))
+	for i, line := range kept {
+		out = append(out, renumberActionLine(line, i+1))
+	}
+	return strings.Join(out, "\n") + "\n"
+}
+
+func actionMentionsAllowedPath(line string, allowed map[string]struct{}) bool {
+	slashLine := filepathToSlash(line)
+	for p := range allowed {
+		if p != "" && strings.Contains(slashLine, p) {
+			return true
+		}
+	}
+	for p := range allowed {
+		base := pathBasename(p)
+		if base == "" || base == p {
+			continue
+		}
+		if strings.Contains(slashLine, base) && pathAllowed(base, allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+var leadingActionNumRe = regexp.MustCompile(`^\d+\.\s*`)
+
+func renumberActionLine(line string, n int) string {
+	rest := leadingActionNumRe.ReplaceAllString(line, "")
+	return fmt.Sprintf("%d. %s", n, rest)
+}
+
+func pathBasename(p string) string {
+	p = filepathToSlash(p)
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
 }
 
 type mdSection struct {

--- a/cmd/ai/sanitize_test.go
+++ b/cmd/ai/sanitize_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractDiffPaths(t *testing.T) {
+	diff := `diff --git a/model/users/user.go b/model/users/user.go
+index 111..222 100644
+--- a/model/users/user.go
++++ b/model/users/user.go
+@@ -1,3 +1,4 @@
++const UserRoleSuperAdmin = 3
+diff --git a/migrations/000040_add_superadmin_role.up.sql b/migrations/000040_add_superadmin_role.up.sql
+new file mode 100644
+--- /dev/null
++++ b/migrations/000040_add_superadmin_role.up.sql
+@@ -0,0 +1,2 @@
++INSERT INTO roles (id_role, name) VALUES (3, 'superadmin');
+`
+	got := extractDiffPaths(diff)
+	assert.Equal(t, []string{
+		"migrations/000040_add_superadmin_role.up.sql",
+		"model/users/user.go",
+	}, got)
+}
+
+func TestSanitizeReview_DropsHallucinatedFindings(t *testing.T) {
+	review := `## Verdict
+BLOCK
+
+## Summary
+Critical issues found.
+
+## Findings
+- [BLOCK] api/user_data.go — SQL injection — Security — Use parameterized queries
+- [WARN] model/users/user.go — Role stored as string — Use enum — Define role enum
+- [NOTE] ci/ci.yml — Missing Clair — Security scan — Configure Clair
+
+## Cursor action list
+1. Implement parameterized queries
+2. Define role enum
+`
+
+	cleaned, dropped := sanitizeReview(review, []string{"model/users/user.go"})
+	require.Equal(t, 2, dropped)
+	assert.Contains(t, cleaned, "## Verdict\nWARN")
+	assert.Contains(t, cleaned, "- [WARN] model/users/user.go")
+	assert.NotContains(t, cleaned, "api/user_data.go")
+	assert.NotContains(t, cleaned, "ci/ci.yml")
+}
+
+func TestSanitizeReview_AllHallucinatedBecomesNone(t *testing.T) {
+	review := `## Verdict
+BLOCK
+
+## Summary
+Critical issues found.
+
+## Findings
+- [BLOCK] api/user_data.go — SQL injection — Security — Use parameterized queries
+- [NOTE] logs/config.go — Logs need encryption — Add TLS
+
+## Cursor action list
+1. Implement parameterized queries
+2. Add TLS for log transport
+`
+
+	cleaned, dropped := sanitizeReview(review, []string{"model/users/user.go"})
+	require.Equal(t, 2, dropped)
+	assert.Contains(t, cleaned, "## Verdict\nOK")
+	assert.Contains(t, cleaned, "## Findings\n- none")
+	assert.Contains(t, cleaned, "## Cursor action list\nnone")
+	assert.NotContains(t, cleaned, "api/user_data.go")
+}
+
+func TestSanitizeReview_NoChangeWhenAllAllowed(t *testing.T) {
+	review := `## Verdict
+WARN
+
+## Summary
+One issue.
+
+## Findings
+- [WARN] model/users/user.go — missing test — Testing — add coverage
+
+## Cursor action list
+1. Add test for model/users/user.go
+`
+	cleaned, dropped := sanitizeReview(review, []string{"model/users/user.go"})
+	assert.Equal(t, 0, dropped)
+	assert.Equal(t, review, cleaned)
+}
+
+func TestPathAllowed_UniqueBasename(t *testing.T) {
+	allowed := map[string]struct{}{
+		"model/users/user.go": {},
+	}
+	assert.True(t, pathAllowed("user.go", allowed))
+	assert.True(t, pathAllowed("model/users/user.go", allowed))
+	assert.False(t, pathAllowed("api/user_data.go", allowed))
+}

--- a/cmd/ai/sanitize_test.go
+++ b/cmd/ai/sanitize_test.go
@@ -41,8 +41,9 @@ Critical issues found.
 - [NOTE] ci/ci.yml — Missing Clair — Security scan — Configure Clair
 
 ## Cursor action list
-1. Implement parameterized queries
-2. Define role enum
+1. Implement parameterized queries in api/user_data.go
+2. Define role enum in model/users/user.go
+3. Configure Clair in ci/ci.yml
 `
 
 	cleaned, dropped := sanitizeReview(review, []string{"model/users/user.go"})
@@ -51,6 +52,34 @@ Critical issues found.
 	assert.Contains(t, cleaned, "- [WARN] model/users/user.go")
 	assert.NotContains(t, cleaned, "api/user_data.go")
 	assert.NotContains(t, cleaned, "ci/ci.yml")
+	assert.Contains(t, cleaned, "## Cursor action list\n1. Define role enum in model/users/user.go")
+	assert.NotContains(t, cleaned, "Implement parameterized queries")
+	assert.NotContains(t, cleaned, "Configure Clair")
+}
+
+func TestSanitizeReview_PartialDropClearsActionsWithoutAllowedPaths(t *testing.T) {
+	review := `## Verdict
+BLOCK
+
+## Summary
+Critical issues found.
+
+## Findings
+- [BLOCK] api/user_data.go — SQL injection — Security — Use parameterized queries
+- [WARN] model/users/user.go — Role stored as string — Use enum — Define role enum
+
+## Cursor action list
+1. Implement parameterized queries
+2. Define role enum
+`
+
+	cleaned, dropped := sanitizeReview(review, []string{"model/users/user.go"})
+	require.Equal(t, 1, dropped)
+	assert.Contains(t, cleaned, "- [WARN] model/users/user.go")
+	assert.Contains(t, cleaned, "## Cursor action list\nnone")
+	assert.NotContains(t, cleaned, "Implement parameterized queries")
+	assert.NotContains(t, cleaned, "1. Define role enum")
+	assert.NotContains(t, cleaned, "2. Define role enum")
 }
 
 func TestSanitizeReview_AllHallucinatedBecomesNone(t *testing.T) {

--- a/internal/handlers/auth/login.go
+++ b/internal/handlers/auth/login.go
@@ -82,7 +82,11 @@ func (lh *LoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if lh.TenantRepo != nil {
+	idRole := uModel.UserRole(user.IDRole)
+
+	// Platform superadmin may log in even when the home tenant is canceled,
+	// so internal APIs can still issue JWTs to reactivate subscriptions.
+	if lh.TenantRepo != nil && idRole != uModel.UserRoleSuperAdmin {
 		snapshot, snapErr := lh.TenantRepo.GetSubscriptionSnapshot(r.Context(), tenantID)
 		if snapErr != nil {
 			http.Error(w, "Could not verify tenant subscription", http.StatusInternalServerError)
@@ -93,8 +97,6 @@ func (lh *LoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
-	idRole := uModel.UserRole(user.IDRole)
 	resolvedTenantID := user.TenantID
 	token, err := lh.AuthService.GenerateJWT(user.ID, idRole, user.Email, &resolvedTenantID)
 	if err != nil {

--- a/internal/handlers/auth/subscription.go
+++ b/internal/handlers/auth/subscription.go
@@ -52,7 +52,7 @@ func (h *SubscriptionHandler) GetSubscription(w http.ResponseWriter, r *http.Req
 	_ = json.NewEncoder(w).Encode(payload)
 }
 
-// UpdateTenantSubscriptionInternal allows superadmin (role admin) to set subscription status and period end.
+// UpdateTenantSubscriptionInternal allows a platform superadmin to set subscription status and period end.
 // PATCH /auth/internal/tenants/{tenant_id}/subscription
 func (h *SubscriptionHandler) UpdateTenantSubscriptionInternal(w http.ResponseWriter, r *http.Request) {
 	if h.Service == nil {

--- a/internal/handlers/auth/subscription_test.go
+++ b/internal/handlers/auth/subscription_test.go
@@ -15,6 +15,7 @@ import (
 	subscriptionService "github.com/radamesvaz/bakery-app/internal/services/subscriptions"
 	authModel "github.com/radamesvaz/bakery-app/model/auth"
 	tenantModel "github.com/radamesvaz/bakery-app/model/tenant"
+	uModel "github.com/radamesvaz/bakery-app/model/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,7 +95,7 @@ func TestSubscriptionHandler_UpdateTenantSubscriptionInternal_Success(t *testing
 	req = mux.SetURLVars(req, map[string]string{"tenant_id": "2"})
 	ctx := context.WithValue(req.Context(), middleware.UserClaimsKey, jwt.MapClaims{
 		"user_id": float64(1),
-		"role_id": float64(1),
+		"role_id": float64(uModel.UserRoleSuperAdmin),
 	})
 	req = req.WithContext(ctx)
 
@@ -119,7 +120,7 @@ func TestSubscriptionHandler_UpdateTenantSubscriptionInternal_Forbidden(t *testi
 	req = mux.SetURLVars(req, map[string]string{"tenant_id": "2"})
 	ctx := context.WithValue(req.Context(), middleware.UserClaimsKey, jwt.MapClaims{
 		"user_id": float64(2),
-		"role_id": float64(2),
+		"role_id": float64(uModel.UserRoleAdmin),
 	})
 	req = req.WithContext(ctx)
 

--- a/internal/handlers/auth/tenant_signup_test.go
+++ b/internal/handlers/auth/tenant_signup_test.go
@@ -18,6 +18,7 @@ import (
 	authService "github.com/radamesvaz/bakery-app/internal/services/auth"
 	tenantSignupService "github.com/radamesvaz/bakery-app/internal/services/tenantsignup"
 	authModel "github.com/radamesvaz/bakery-app/model/auth"
+	uModel "github.com/radamesvaz/bakery-app/model/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestTenantSignupHandler_CreateSignupCode_Success(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	ctx := context.WithValue(req.Context(), middleware.UserClaimsKey, jwt.MapClaims{
 		"user_id": float64(99),
-		"role_id": float64(1),
+		"role_id": float64(uModel.UserRoleSuperAdmin),
 	})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
@@ -56,6 +57,52 @@ func TestTenantSignupHandler_CreateSignupCode_Success(t *testing.T) {
 	assert.NotEmpty(t, resp.Code)
 	assert.True(t, resp.ExpiresAt.After(time.Now().UTC().Add(100*time.Minute)))
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTenantSignupHandler_CreateSignupCode_ForbiddenForTenantAdmin(t *testing.T) {
+	svc := &tenantSignupService.TenantSignupService{
+		Repo:        &tenantSignupRepo.Repository{DB: nil},
+		AuthService: authService.New("testingsecret", 60),
+	}
+	handler := &TenantSignupHandler{Service: svc}
+
+	body := bytes.NewBufferString(`{"expires_in_minutes":120,"notes":"should be forbidden"}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/internal/tenant-signup-codes", body)
+	req.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(req.Context(), middleware.UserClaimsKey, jwt.MapClaims{
+		"user_id": float64(99),
+		"role_id": float64(uModel.UserRoleAdmin),
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.CreateSignupCode(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Forbidden")
+}
+
+func TestTenantSignupHandler_CreateSignupCode_ForbiddenForClient(t *testing.T) {
+	svc := &tenantSignupService.TenantSignupService{
+		Repo:        &tenantSignupRepo.Repository{DB: nil},
+		AuthService: authService.New("testingsecret", 60),
+	}
+	handler := &TenantSignupHandler{Service: svc}
+
+	body := bytes.NewBufferString(`{"expires_in_minutes":120}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/internal/tenant-signup-codes", body)
+	req.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(req.Context(), middleware.UserClaimsKey, jwt.MapClaims{
+		"user_id": float64(50),
+		"role_id": float64(uModel.UserRoleClient),
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.CreateSignupCode(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Forbidden")
 }
 
 func TestTenantSignupHandler_RegisterTenantWithCode_Success(t *testing.T) {
@@ -130,7 +177,7 @@ func TestTenantSignupHandler_CreateSignupCode_DefaultTTL120(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	ctx := context.WithValue(req.Context(), middleware.UserClaimsKey, jwt.MapClaims{
 		"user_id": float64(99),
-		"role_id": float64(1),
+		"role_id": float64(uModel.UserRoleSuperAdmin),
 	})
 	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/radamesvaz/bakery-app/internal/services/auth"
+	uModel "github.com/radamesvaz/bakery-app/model/users"
 )
 
 // TenantSlugResolver resolves slug from tenant id when the route has no {tenant_slug}
@@ -68,7 +69,7 @@ func AuthMiddleware(authService auth.Service) func(http.Handler) http.Handler {
 // - tenantID:
 //   - From the "tenant_id" JWT claim when present; otherwise 1 for backwards compatibility.
 // - isSuperadmin:
-//   - Derived from the "role_id" claim (UserRoleAdmin is treated as superadmin).
+//   - Derived from the "role_id" claim (UserRoleSuperAdmin only).
 func TenantMiddleware(slugResolver TenantSlugResolver) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -80,13 +81,10 @@ func TenantMiddleware(slugResolver TenantSlugResolver) func(http.Handler) http.H
 				return
 			}
 
-			// Determine if user is superadmin based on role_id claim.
+			// Determine if user is platform superadmin based on role_id claim.
 			isSuperadmin := false
 			if roleIDFloat, ok := claims["role_id"].(float64); ok {
-				// Today, role_id=1 is admin; we treat it as superadmin in the
-				// multi-tenant model.
-				const userRoleAdmin = 1
-				if uint64(roleIDFloat) == userRoleAdmin {
+				if uint64(roleIDFloat) == uint64(uModel.UserRoleSuperAdmin) {
 					isSuperadmin = true
 				}
 			}

--- a/internal/services/subscriptions/service.go
+++ b/internal/services/subscriptions/service.go
@@ -83,7 +83,7 @@ func (s *Service) GetSubscriptionForTenant(ctx context.Context, tenantID uint64,
 	return response, nil
 }
 
-// AdminUpdateSubscription allows a superadmin (role admin) to change subscription status and period end.
+// AdminUpdateSubscription allows a platform superadmin to change subscription status and period end.
 func (s *Service) AdminUpdateSubscription(
 	ctx context.Context,
 	roleID uint64,
@@ -91,7 +91,7 @@ func (s *Service) AdminUpdateSubscription(
 	req authModel.UpdateTenantSubscriptionRequest,
 	now time.Time,
 ) (authModel.UpdateTenantSubscriptionResponse, error) {
-	if roleID != uint64(uModel.UserRoleAdmin) {
+	if roleID != uint64(uModel.UserRoleSuperAdmin) {
 		return authModel.UpdateTenantSubscriptionResponse{}, ErrForbidden
 	}
 

--- a/internal/services/subscriptions/service_test.go
+++ b/internal/services/subscriptions/service_test.go
@@ -9,6 +9,7 @@ import (
 	tenantRepo "github.com/radamesvaz/bakery-app/internal/repository/tenant"
 	authModel "github.com/radamesvaz/bakery-app/model/auth"
 	tenantModel "github.com/radamesvaz/bakery-app/model/tenant"
+	uModel "github.com/radamesvaz/bakery-app/model/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,17 +99,23 @@ func TestService_ProcessTransitions_ReturnsCounts(t *testing.T) {
 	assert.Equal(t, 7, repo.lastGraceDays)
 }
 
-func TestService_AdminUpdateSubscription_ForbiddenForNonAdmin(t *testing.T) {
+func TestService_AdminUpdateSubscription_ForbiddenForNonSuperAdmin(t *testing.T) {
 	svc := NewService(&fakeRepo{}, 5)
-	_, err := svc.AdminUpdateSubscription(
-		context.Background(),
-		2,
-		10,
-		authModel.UpdateTenantSubscriptionRequest{SubscriptionStatus: "active"},
-		time.Now().UTC(),
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrForbidden)
+
+	for _, roleID := range []uint64{
+		uint64(uModel.UserRoleAdmin),
+		uint64(uModel.UserRoleClient),
+	} {
+		_, err := svc.AdminUpdateSubscription(
+			context.Background(),
+			roleID,
+			10,
+			authModel.UpdateTenantSubscriptionRequest{SubscriptionStatus: "active"},
+			time.Now().UTC(),
+		)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrForbidden)
+	}
 }
 
 func TestService_AdminUpdateSubscription_ActiveSetsDefault30DayPeriod(t *testing.T) {
@@ -120,7 +127,7 @@ func TestService_AdminUpdateSubscription_ActiveSetsDefault30DayPeriod(t *testing
 
 	resp, err := svc.AdminUpdateSubscription(
 		context.Background(),
-		1,
+		uint64(uModel.UserRoleSuperAdmin),
 		10,
 		authModel.UpdateTenantSubscriptionRequest{SubscriptionStatus: "active"},
 		now,

--- a/internal/services/tenantsignup/service.go
+++ b/internal/services/tenantsignup/service.go
@@ -32,7 +32,7 @@ func (s *TenantSignupService) CreateSignupCode(
 	createdByUserID uint64,
 	req authModel.CreateSignupCodeRequest,
 ) (authModel.CreateSignupCodeResponse, error) {
-	if roleID != uint64(uModel.UserRoleAdmin) {
+	if roleID != uint64(uModel.UserRoleSuperAdmin) {
 		return authModel.CreateSignupCodeResponse{}, ErrForbidden
 	}
 

--- a/migrations/000040_add_superadmin_role.down.sql
+++ b/migrations/000040_add_superadmin_role.down.sql
@@ -1,1 +1,4 @@
+-- Remove all users with the superadmin role before deleting the role,
+-- otherwise users.id_role FK (fk_role) blocks the DELETE.
+DELETE FROM users WHERE id_role = 3;
 DELETE FROM roles WHERE id_role = 3 AND name = 'superadmin';

--- a/migrations/000040_add_superadmin_role.down.sql
+++ b/migrations/000040_add_superadmin_role.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM roles WHERE id_role = 3 AND name = 'superadmin';

--- a/migrations/000040_add_superadmin_role.up.sql
+++ b/migrations/000040_add_superadmin_role.up.sql
@@ -1,0 +1,3 @@
+INSERT INTO roles (id_role, name) VALUES (3, 'superadmin');
+
+SELECT setval(pg_get_serial_sequence('roles', 'id_role'), (SELECT MAX(id_role) FROM roles));

--- a/migrations/000040_add_superadmin_role.up.sql
+++ b/migrations/000040_add_superadmin_role.up.sql
@@ -1,3 +1,18 @@
 INSERT INTO roles (id_role, name) VALUES (3, 'superadmin');
 
 SELECT setval(pg_get_serial_sequence('roles', 'id_role'), (SELECT MAX(id_role) FROM roles));
+
+-- Platform operator for internal APIs (tenant signup codes, etc.).
+-- Password hash matches seeded adminpass from 000003 (bcrypt cost 10).
+INSERT INTO users (tenant_id, id_role, name, email, phone, password_hash, created_on)
+SELECT
+  1,
+  3,
+  'Super Admin',
+  'superadmin@example.com',
+  '00-00000',
+  '$2a$10$SO6GoHITlrEuH9mZyaFqN.vmtx9F0mn.4c2Blp7xM9WCM1svOMnYq',
+  NOW()
+WHERE NOT EXISTS (
+  SELECT 1 FROM users WHERE tenant_id = 1 AND email = 'superadmin@example.com'
+);

--- a/model/users/user.go
+++ b/model/users/user.go
@@ -7,8 +7,9 @@ import (
 type UserRole uint64
 
 const (
-	UserRoleAdmin  UserRole = 1
-	UserRoleClient UserRole = 2
+	UserRoleAdmin      UserRole = 1
+	UserRoleClient     UserRole = 2
+	UserRoleSuperAdmin UserRole = 3
 )
 
 type User struct {

--- a/run.sh
+++ b/run.sh
@@ -174,6 +174,45 @@ reset() {
   echo "✅ Project is up and running!"
 }
 
+# Local architecture review via Ollama (default model: qwen3:8b).
+# Requires Ollama running locally (http://localhost:11434).
+#
+# What each mode reviews (and whether Ollama is called):
+#
+#   ./run.sh review
+#     Diff: working tree vs HEAD + untracked (new files not yet git-added).
+#     Calls Ollama and saves under .ai/reviews/ (default -save when no flags).
+#     Use when: "review what I have dirty on disk right now".
+#
+#   ./run.sh review -staged
+#     Diff: only the git index (git diff --staged).
+#     Ignores unstaged and untracked changes.
+#     Use when: "review what I'm about to commit".
+#
+#   ./run.sh review -base main
+#     Diff: main...HEAD (commits on your branch vs main).
+#     Ignores a dirty working tree; looks at branch history.
+#     Use when: "review the PR / whole feature vs main".
+#     Mutually exclusive with -staged.
+#
+#   ./run.sh review -dry-run
+#     Does NOT call Ollama. Prints the assembled prompt (guidelines + diff).
+#     Use when: debugging prompt size/content without spending model time.
+#     Combinable, e.g. ./run.sh review -base main -dry-run
+#
+# Other useful flags (forwarded to cmd/ai):
+#   -model NAME   override model (default qwen3:8b, or OLLAMA_MODEL)
+#   -host URL     Ollama base URL (default http://localhost:11434)
+#   -save         write review under .ai/reviews/
+review() {
+  echo -e "${YELLOW}🔍 Running local architecture review (Ollama)...${NC}"
+  if [ "$#" -eq 0 ]; then
+    go run ./cmd/ai review -save
+  else
+    go run ./cmd/ai review "$@"
+  fi
+}
+
 case "$1" in
   unit)
     unit
@@ -205,6 +244,10 @@ case "$1" in
   reset)
     reset
     ;;
+  review)
+    shift
+    review "$@"
+    ;;
   *)
     echo -e "${RED}⚠️  Command not recognized: $1${NC}"
     echo -e "${YELLOW}👉 Available commands:${NC}"
@@ -218,5 +261,6 @@ case "$1" in
     echo -e "${YELLOW}   integration - Run integration tests${NC}"
     echo -e "${YELLOW}   tests      - Run all tests${NC}"
     echo -e "${YELLOW}   reset      - Reset project (full rebuild)${NC}"
+    echo -e "${YELLOW}   review     - Local architecture review with Ollama (saves under .ai/reviews/)${NC}"
     ;;
 esac

--- a/run.sh
+++ b/run.sh
@@ -181,36 +181,56 @@ reset() {
 #
 #   ./run.sh review
 #     Diff: working tree vs HEAD + untracked (new files not yet git-added).
-#     Calls Ollama and saves under .ai/reviews/ (default -save when no flags).
+#     Calls Ollama and saves under .ai/reviews/.
 #     Use when: "review what I have dirty on disk right now".
 #
 #   ./run.sh review -staged
 #     Diff: only the git index (git diff --staged).
-#     Ignores unstaged and untracked changes.
+#     Ignores unstaged and untracked changes. Saves under .ai/reviews/.
 #     Use when: "review what I'm about to commit".
 #
-#   ./run.sh review -base main
-#     Diff: main...HEAD (commits on your branch vs main).
-#     Ignores a dirty working tree; looks at branch history.
-#     Use when: "review the PR / whole feature vs main".
+#   ./run.sh review -base master
+#     Diff: master...HEAD (commits on your branch vs the default branch).
+#     -base main also works: it resolves to master when main does not exist.
+#     Ignores a dirty working tree; looks at branch history. Saves under .ai/reviews/.
+#     Use when: "review the PR / whole feature vs master".
 #     Mutually exclusive with -staged.
 #
 #   ./run.sh review -dry-run
 #     Does NOT call Ollama. Prints the assembled prompt (guidelines + diff).
+#     Does NOT save a review file.
 #     Use when: debugging prompt size/content without spending model time.
-#     Combinable, e.g. ./run.sh review -base main -dry-run
+#     Combinable, e.g. ./run.sh review -base master -dry-run
 #
 # Other useful flags (forwarded to cmd/ai):
 #   -model NAME   override model (default qwen3:8b, or OLLAMA_MODEL)
 #   -host URL     Ollama base URL (default http://localhost:11434)
-#   -save         write review under .ai/reviews/
+#   -save         write review under .ai/reviews/ (already default via run.sh)
+#
+# Via ./run.sh, reviews are saved under .ai/reviews/ by default for all modes
+# except -dry-run. Pass flags as usual; -save is added automatically when missing.
 review() {
   echo -e "${YELLOW}🔍 Running local architecture review (Ollama)...${NC}"
-  if [ "$#" -eq 0 ]; then
-    go run ./cmd/ai review -save
-  else
-    go run ./cmd/ai review "$@"
+
+  args=("$@")
+  wants_save=true
+  for arg in "${args[@]}"; do
+    case "$arg" in
+      -dry-run)
+        wants_save=false
+        break
+        ;;
+      -save)
+        wants_save=false
+        break
+        ;;
+    esac
+  done
+  if [ "$wants_save" = true ]; then
+    args+=(-save)
   fi
+
+  go run ./cmd/ai review "${args[@]}"
 }
 
 case "$1" in

--- a/seeds/001_multi_tenant_mock.sql
+++ b/seeds/001_multi_tenant_mock.sql
@@ -9,6 +9,10 @@ SET password_hash = '$2a$10$Ued/UmuZslCPE.c.iRdFEON7jicWeAlBBM3vjLrcktSg778XHtvQ
 WHERE id_role = (SELECT id_role FROM roles WHERE name = 'admin');
 
 UPDATE users
+SET password_hash = '$2a$10$Ued/UmuZslCPE.c.iRdFEON7jicWeAlBBM3vjLrcktSg778XHtvQW'
+WHERE id_role = (SELECT id_role FROM roles WHERE name = 'superadmin');
+
+UPDATE users
 SET password_hash = '$2a$10$VdS6bqypHg1a5ZJjKOovjuo4KRwMMegIJ11MZCDYLB/fufAY9OPh6'
 WHERE id_role = (SELECT id_role FROM roles WHERE name = 'client');
 

--- a/tests/login_test.go
+++ b/tests/login_test.go
@@ -101,3 +101,63 @@ func TestLogin_SoftDeletedUserCannotLogin(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t, rr.Body.String(), "User not found")
 }
+
+func TestLogin_CanceledTenant_BlocksAdmin(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `
+		UPDATE tenants SET subscription_status = 'canceled' WHERE id = 1`)
+	require.NoError(t, err)
+
+	handler := auth.LoginHandler{
+		UserRepo:    user.UserRepository{DB: db},
+		TenantRepo:  &tenantRepository.Repository{DB: db},
+		AuthService: authService.New("testingsecret", 60),
+	}
+	router := mux.NewRouter()
+	router.HandleFunc("/login", handler.Login).Methods("POST")
+
+	req := httptest.NewRequest("POST", "/login", strings.NewReader(`{
+		"email": "admin@example.com",
+		"password": "adminpass"
+	}`))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Tenant subscription is canceled")
+}
+
+func TestLogin_CanceledTenant_AllowsSuperAdmin(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `
+		UPDATE tenants SET subscription_status = 'canceled' WHERE id = 1`)
+	require.NoError(t, err)
+
+	handler := auth.LoginHandler{
+		UserRepo:    user.UserRepository{DB: db},
+		TenantRepo:  &tenantRepository.Repository{DB: db},
+		AuthService: authService.New("testingsecret", 60),
+	}
+	router := mux.NewRouter()
+	router.HandleFunc("/login", handler.Login).Methods("POST")
+
+	req := httptest.NewRequest("POST", "/login", strings.NewReader(`{
+		"email": "superadmin@example.com",
+		"password": "adminpass"
+	}`))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var loginBody auth.LoginResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &loginBody))
+	assert.NotEmpty(t, loginBody.Token)
+}

--- a/tests/tenant_signup_integration_test.go
+++ b/tests/tenant_signup_integration_test.go
@@ -14,11 +14,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	authHandler "github.com/radamesvaz/bakery-app/internal/handlers/auth"
 	"github.com/radamesvaz/bakery-app/internal/middleware"
 	tenantRepository "github.com/radamesvaz/bakery-app/internal/repository/tenant"
 	tenantSignupRepo "github.com/radamesvaz/bakery-app/internal/repository/tenantsignup"
+	"github.com/radamesvaz/bakery-app/internal/repository/user"
 	authService "github.com/radamesvaz/bakery-app/internal/services/auth"
 	tenantSignupService "github.com/radamesvaz/bakery-app/internal/services/tenantsignup"
 	authModel "github.com/radamesvaz/bakery-app/model/auth"
@@ -28,10 +30,12 @@ import (
 )
 
 type tenantSignupIntegrationEnv struct {
-	router         *mux.Router
-	db             *sql.DB
-	superadminJWT  string
-	tenantAdminJWT string
+	router           *mux.Router
+	db               *sql.DB
+	authSvc          authService.Service
+	superadminUserID uint64
+	superadminJWT    string
+	tenantAdminJWT   string
 }
 
 func setupTenantSignupIntegrationEnv(t *testing.T) (*tenantSignupIntegrationEnv, func()) {
@@ -46,29 +50,52 @@ func setupTenantSignupIntegrationEnv(t *testing.T) (*tenantSignupIntegrationEnv,
 		AuthService: authSvc,
 	}
 	handler := &authHandler.TenantSignupHandler{Service: svc}
+	tenantRepo := &tenantRepository.Repository{DB: db}
+	loginHandler := &authHandler.LoginHandler{
+		UserRepo:    user.UserRepository{DB: db},
+		TenantRepo:  tenantRepo,
+		AuthService: authSvc,
+	}
 
 	router := mux.NewRouter()
+	router.HandleFunc("/login", loginHandler.Login).Methods("POST")
 	router.HandleFunc("/public/tenant-register", handler.RegisterTenantWithCode).Methods("POST")
-	tenantRepo := &tenantRepository.Repository{DB: db}
 	authRouter := router.PathPrefix("/auth").Subrouter()
 	authRouter.Use(middleware.AuthMiddleware(authSvc))
 	authRouter.Use(middleware.TenantMiddleware(tenantRepo))
 	authRouter.HandleFunc("/internal/tenant-signup-codes", handler.CreateSignupCode).Methods("POST")
 
 	defaultTenantID := uint64(1)
-	superadminJWT, err := authSvc.GenerateJWT(1, uModel.UserRoleSuperAdmin, "superadmin@example.com", &defaultTenantID)
+	superadminID := lookupUserIDByEmailAndRole(t, db, "superadmin@example.com", uModel.UserRoleSuperAdmin)
+	adminID := lookupUserIDByEmailAndRole(t, db, "admin@example.com", uModel.UserRoleAdmin)
+
+	superadminJWT, err := authSvc.GenerateJWT(superadminID, uModel.UserRoleSuperAdmin, "superadmin@example.com", &defaultTenantID)
 	require.NoError(t, err)
-	tenantAdminJWT, err := authSvc.GenerateJWT(2, uModel.UserRoleAdmin, "admin@example.com", &defaultTenantID)
+	tenantAdminJWT, err := authSvc.GenerateJWT(adminID, uModel.UserRoleAdmin, "admin@example.com", &defaultTenantID)
 	require.NoError(t, err)
 
 	return &tenantSignupIntegrationEnv{
-			router:         router,
-			db:             db,
-			superadminJWT:  superadminJWT,
-			tenantAdminJWT: tenantAdminJWT,
+			router:           router,
+			db:               db,
+			authSvc:          authSvc,
+			superadminUserID: superadminID,
+			superadminJWT:    superadminJWT,
+			tenantAdminJWT:   tenantAdminJWT,
 		}, func() {
 			terminate()
 		}
+}
+
+func lookupUserIDByEmailAndRole(t *testing.T, db *sql.DB, email string, role uModel.UserRole) uint64 {
+	t.Helper()
+	var id uint64
+	err := db.QueryRow(
+		`SELECT id_user FROM users WHERE tenant_id = 1 AND email = $1 AND id_role = $2 AND deleted_at IS NULL`,
+		email,
+		role,
+	).Scan(&id)
+	require.NoError(t, err, "expected seeded user %s with role %d", email, role)
+	return id
 }
 
 func createSignupCodeInternal(
@@ -168,6 +195,46 @@ func TestTenantSignupIntegration_CreateSignupCode_ForbiddenForTenantAdmin(t *tes
 	assert.Contains(t, rr.Body.String(), "Forbidden")
 }
 
+func TestTenantSignupIntegration_CreateSignupCode_AfterSuperAdminLogin(t *testing.T) {
+	env, cleanup := setupTenantSignupIntegrationEnv(t)
+	defer cleanup()
+
+	loginReq := httptest.NewRequest(
+		http.MethodPost,
+		"/login",
+		strings.NewReader(`{"email":"superadmin@example.com","password":"adminpass"}`),
+	)
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRR := httptest.NewRecorder()
+	env.router.ServeHTTP(loginRR, loginReq)
+	require.Equal(t, http.StatusOK, loginRR.Code, loginRR.Body.String())
+
+	var loginBody authHandler.LoginResponse
+	require.NoError(t, json.Unmarshal(loginRR.Body.Bytes(), &loginBody))
+	require.NotEmpty(t, loginBody.Token)
+
+	parsed, err := env.authSvc.ValidateToken(loginBody.Token)
+	require.NoError(t, err)
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	assert.Equal(t, float64(uModel.UserRoleSuperAdmin), claims["role_id"])
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/auth/internal/tenant-signup-codes",
+		strings.NewReader(`{"expires_in_minutes":60,"notes":"from login flow"}`),
+	)
+	req.Header.Set("Authorization", "Bearer "+loginBody.Token)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	env.router.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	var resp authModel.CreateSignupCodeResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Code)
+}
+
 func TestTenantSignupIntegration_RegisterWithCode_HappyPath(t *testing.T) {
 	env, cleanup := setupTenantSignupIntegrationEnv(t)
 	defer cleanup()
@@ -217,7 +284,7 @@ func TestTenantSignupIntegration_RegisterWithCode_HappyPath(t *testing.T) {
 	assert.Equal(t, int64(resp.TenantID), usedByTenantID.Int64)
 	assert.Equal(t, int64(resp.AdminID), usedByUserID.Int64)
 	assert.Equal(t, email, usedEmail.String)
-	assert.Equal(t, int64(1), createdBy.Int64)
+	assert.Equal(t, int64(env.superadminUserID), createdBy.Int64)
 }
 
 func TestTenantSignupIntegration_RegisterWithCode_ReusedCodeReturns422(t *testing.T) {

--- a/tests/tenant_signup_integration_test.go
+++ b/tests/tenant_signup_integration_test.go
@@ -28,9 +28,10 @@ import (
 )
 
 type tenantSignupIntegrationEnv struct {
-	router   *mux.Router
-	db       *sql.DB
-	adminJWT string
+	router         *mux.Router
+	db             *sql.DB
+	superadminJWT  string
+	tenantAdminJWT string
 }
 
 func setupTenantSignupIntegrationEnv(t *testing.T) (*tenantSignupIntegrationEnv, func()) {
@@ -55,13 +56,16 @@ func setupTenantSignupIntegrationEnv(t *testing.T) (*tenantSignupIntegrationEnv,
 	authRouter.HandleFunc("/internal/tenant-signup-codes", handler.CreateSignupCode).Methods("POST")
 
 	defaultTenantID := uint64(1)
-	adminJWT, err := authSvc.GenerateJWT(1, uModel.UserRoleAdmin, "admin@example.com", &defaultTenantID)
+	superadminJWT, err := authSvc.GenerateJWT(1, uModel.UserRoleSuperAdmin, "superadmin@example.com", &defaultTenantID)
+	require.NoError(t, err)
+	tenantAdminJWT, err := authSvc.GenerateJWT(2, uModel.UserRoleAdmin, "admin@example.com", &defaultTenantID)
 	require.NoError(t, err)
 
 	return &tenantSignupIntegrationEnv{
-			router:   router,
-			db:       db,
-			adminJWT: adminJWT,
+			router:         router,
+			db:             db,
+			superadminJWT:  superadminJWT,
+			tenantAdminJWT: tenantAdminJWT,
 		}, func() {
 			terminate()
 		}
@@ -77,7 +81,7 @@ func createSignupCodeInternal(
 
 	reqBody := fmt.Sprintf(`{"expires_in_minutes":%d,"notes":"%s"}`, ttlMinutes, notes)
 	req := httptest.NewRequest(http.MethodPost, "/auth/internal/tenant-signup-codes", strings.NewReader(reqBody))
-	req.Header.Set("Authorization", "Bearer "+env.adminJWT)
+	req.Header.Set("Authorization", "Bearer "+env.superadminJWT)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -143,6 +147,25 @@ func insertSignupCodeForTest(t *testing.T, db *sql.DB, plainCode string, expires
 		"integration seeded code",
 	)
 	require.NoError(t, err)
+}
+
+func TestTenantSignupIntegration_CreateSignupCode_ForbiddenForTenantAdmin(t *testing.T) {
+	env, cleanup := setupTenantSignupIntegrationEnv(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/auth/internal/tenant-signup-codes",
+		strings.NewReader(`{"expires_in_minutes":120,"notes":"tenant admin should be forbidden"}`),
+	)
+	req.Header.Set("Authorization", "Bearer "+env.tenantAdminJWT)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	env.router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "Forbidden")
 }
 
 func TestTenantSignupIntegration_RegisterWithCode_HappyPath(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes who may call privileged internal auth APIs and alters login behavior for canceled tenants; incorrect role checks could lock out operators or over-grant platform powers.
> 
> **Overview**
> Adds a dedicated **platform superadmin** role (`UserRoleSuperAdmin` / DB role `superadmin`) via migration `000040`, including a seeded `superadmin@example.com` user and dev seed password alignment.
> 
> **Authorization** no longer treats tenant **admin** as platform superadmin: `TenantMiddleware` sets `isSuperadmin` only for role 3; **tenant signup codes** and **internal subscription updates** are restricted to superadmin (tenant admins and clients get forbidden). Tests and integration flows are updated accordingly.
> 
> **Login** skips the canceled-subscription block for superadmin so operators can still obtain JWTs to reactivate tenants; regular admins remain blocked when the home tenant is canceled.
> 
> Also ships **`cmd/ai`** — a local architecture review tool that builds prompts from `.ai/memory` guidelines, diffs git (including untracked files), calls Ollama, and sanitizes model output to diff paths only — plus **`./run.sh review`** wiring and `.gitignore` for generated review markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ad6125a7e922b422c2b40c8984497c666f6a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->