### PR TITLE
resolving new tenant slug

### DIFF
--- a/internal/handlers/auth/tenant_signup.go
+++ b/internal/handlers/auth/tenant_signup.go
@@ -93,7 +93,10 @@ func (h *TenantSignupHandler) RegisterTenantWithCode(w http.ResponseWriter, r *h
 	}
 	tenantSlug := strings.TrimSpace(strings.ToLower(req.TenantSlug))
 	if tenantSlug == "" {
-		http.Error(w, "Tenant slug is required", http.StatusBadRequest)
+		tenantSlug = tenantSignupService.SlugifyTenantName(tenantName)
+	}
+	if tenantSlug == "" {
+		http.Error(w, "Could not derive tenant slug from tenant name", http.StatusBadRequest)
 		return
 	}
 	if strings.TrimSpace(req.AdminName) == "" {
@@ -122,7 +125,11 @@ func (h *TenantSignupHandler) RegisterTenantWithCode(w http.ResponseWriter, r *h
 			http.Error(w, "Invalid or unavailable one-time code", http.StatusUnprocessableEntity)
 			return
 		case errors.Is(err, tenantSignupService.ErrTenantSlugExists):
-			http.Error(w, "Tenant slug already exists", http.StatusConflict)
+			// Exhausted auto-suffix attempts; rare. Ask for a different business name.
+			http.Error(w, "Business name is not available, please choose another", http.StatusConflict)
+			return
+		case errors.Is(err, tenantSignupService.ErrInvalidTenantSlug):
+			http.Error(w, "Could not derive tenant slug from tenant name", http.StatusBadRequest)
 			return
 		case errors.Is(err, tenantSignupService.ErrAdminEmailExists):
 			http.Error(w, "Admin email already exists in tenant", http.StatusConflict)

--- a/internal/handlers/auth/tenant_signup_test.go
+++ b/internal/handlers/auth/tenant_signup_test.go
@@ -362,7 +362,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithUnknownOTC_Returns422(t 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_Returns409(t *testing.T) {
+func TestTenantSignupHandler_RegisterTenantWithCode_WithoutSlug_DerivesFromName(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close()
@@ -370,6 +370,59 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_Returns409
 	svc := &tenantSignupService.TenantSignupService{
 		Repo:        &tenantSignupRepo.Repository{DB: db},
 		AuthService: authService.New("testingsecret", 60),
+		EmailSender: email.NoopSender{},
+		AppBaseURL:  "https://admin.example.com",
+	}
+	handler := &TenantSignupHandler{Service: svc}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT id, expires_at, used_at, revoked_at`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "expires_at", "used_at", "revoked_at"}).
+			AddRow(uint64(5), time.Now().UTC().Add(2*time.Hour), nil, nil))
+	mock.ExpectQuery(`INSERT INTO tenants`).
+		WithArgs("Acme Bakery", "acme-bakery").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uint64(10)))
+	mock.ExpectQuery(`INSERT INTO users`).
+		WithArgs(uint64(10), 1, "Owner Admin", "owner@acme.com", "555-0101", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id_user"}).AddRow(uint64(100)))
+	mock.ExpectExec(`UPDATE tenant_signup_codes`).
+		WithArgs(uint64(5), uint64(10), uint64(100), "owner@acme.com").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	body := bytes.NewBufferString(`{
+		"tenant_name":"Acme Bakery",
+		"admin_name":"Owner Admin",
+		"email":"owner@acme.com",
+		"phone":"555-0101",
+		"password":"StrongPass123!",
+		"one_time_code":"ABCD1234-EFGH5678"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/public/tenant-register", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	handler.RegisterTenantWithCode(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	var resp authModel.PublicTenantRegisterResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "acme-bakery", resp.TenantSlug)
+	assert.Equal(t, "Acme Bakery", resp.TenantName)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_AutoSuffixes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	svc := &tenantSignupService.TenantSignupService{
+		Repo:        &tenantSignupRepo.Repository{DB: db},
+		AuthService: authService.New("testingsecret", 60),
+		EmailSender: email.NoopSender{},
+		AppBaseURL:  "https://admin.example.com",
 	}
 	handler := &TenantSignupHandler{Service: svc}
 
@@ -383,6 +436,22 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_Returns409
 		WillReturnError(&pq.Error{Code: "23505"})
 	mock.ExpectRollback()
 
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT id, expires_at, used_at, revoked_at`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "expires_at", "used_at", "revoked_at"}).
+			AddRow(uint64(5), time.Now().UTC().Add(2*time.Hour), nil, nil))
+	mock.ExpectQuery(`INSERT INTO tenants`).
+		WithArgs("Acme Bakery", "acme-2").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uint64(10)))
+	mock.ExpectQuery(`INSERT INTO users`).
+		WithArgs(uint64(10), 1, "Owner Admin", "owner@acme.com", "555-0101", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id_user"}).AddRow(uint64(100)))
+	mock.ExpectExec(`UPDATE tenant_signup_codes`).
+		WithArgs(uint64(5), uint64(10), uint64(100), "owner@acme.com").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
 	req := httptest.NewRequest(http.MethodPost, "/public/tenant-register",
 		bytes.NewBufferString(validRegisterBody("ABCD1234-EFGH5678")))
 	req.Header.Set("Content-Type", "application/json")
@@ -390,8 +459,10 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_Returns409
 
 	handler.RegisterTenantWithCode(rr, req)
 
-	assert.Equal(t, http.StatusConflict, rr.Code, rr.Body.String())
-	assert.Contains(t, rr.Body.String(), "Tenant slug already exists")
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	var resp authModel.PublicTenantRegisterResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "acme-2", resp.TenantSlug)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/services/tenantsignup/service.go
+++ b/internal/services/tenantsignup/service.go
@@ -17,10 +17,12 @@ import (
 )
 
 const defaultSignupCodeTTLMinutes = 120
+const maxTenantSlugSuffixAttempts = 50
 
 var (
 	ErrForbidden                = errors.New("forbidden")
 	ErrInvalidEmail             = errors.New("invalid email")
+	ErrInvalidTenantSlug        = errors.New("invalid tenant slug")
 	ErrEmailNotConfigured       = errors.New("email sender not configured")
 	ErrEmailDeliveryFailed      = errors.New("email delivery failed")
 	ErrAppBaseURLRequired       = errors.New("APP_BASE_URL is required for signup links")
@@ -104,15 +106,41 @@ func (s *TenantSignupService) RegisterTenantWithCode(ctx context.Context, req au
 		return authModel.PublicTenantRegisterResponse{}, err
 	}
 
-	result, err := s.Repo.RegisterTenantWithCode(ctx, repo.RegisterTenantWithCodeInput{
-		CodeHash:     s.AuthService.HashOneTimeToken(req.OneTimeCode),
-		TenantName:   req.TenantName,
-		TenantSlug:   req.TenantSlug,
-		AdminName:    strings.TrimSpace(req.AdminName),
-		AdminEmail:   adminEmail,
-		AdminPhone:   strings.TrimSpace(req.Phone),
-		PasswordHash: hashedPassword,
-	})
+	baseSlug := strings.TrimSpace(strings.ToLower(req.TenantSlug))
+	if baseSlug == "" {
+		baseSlug = SlugifyTenantName(req.TenantName)
+	}
+	if baseSlug == "" {
+		return authModel.PublicTenantRegisterResponse{}, ErrInvalidTenantSlug
+	}
+
+	codeHash := s.AuthService.HashOneTimeToken(req.OneTimeCode)
+	adminName := strings.TrimSpace(req.AdminName)
+	adminPhone := strings.TrimSpace(req.Phone)
+
+	var (
+		result repo.RegisterTenantWithCodeResult
+		slug   string
+	)
+	for attempt := 1; attempt <= maxTenantSlugSuffixAttempts; attempt++ {
+		slug = TenantSlugCandidate(baseSlug, attempt)
+		result, err = s.Repo.RegisterTenantWithCode(ctx, repo.RegisterTenantWithCodeInput{
+			CodeHash:     codeHash,
+			TenantName:   req.TenantName,
+			TenantSlug:   slug,
+			AdminName:    adminName,
+			AdminEmail:   adminEmail,
+			AdminPhone:   adminPhone,
+			PasswordHash: hashedPassword,
+		})
+		if err == nil {
+			break
+		}
+		if errors.Is(err, ErrTenantSlugExists) {
+			continue
+		}
+		return authModel.PublicTenantRegisterResponse{}, err
+	}
 	if err != nil {
 		return authModel.PublicTenantRegisterResponse{}, err
 	}
@@ -126,7 +154,7 @@ func (s *TenantSignupService) RegisterTenantWithCode(ctx context.Context, req au
 		Message:    "Tenant registered successfully",
 		Token:      token,
 		TenantID:   result.TenantID,
-		TenantSlug: req.TenantSlug,
+		TenantSlug: slug,
 		TenantName: req.TenantName,
 		AdminID:    result.AdminID,
 		AdminEmail: adminEmail,

--- a/internal/services/tenantsignup/slug.go
+++ b/internal/services/tenantsignup/slug.go
@@ -1,0 +1,91 @@
+package tenantsignup
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const MaxTenantSlugLen = 64
+
+// SlugifyTenantName builds a URL-safe slug from a display name (lowercase, hyphens).
+// Empty input yields empty string; callers should treat that as invalid.
+func SlugifyTenantName(name string) string {
+	s := strings.TrimSpace(strings.ToLower(name))
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	prevHyphen := false
+	for _, r := range s {
+		r = foldLatinRune(r)
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevHyphen = false
+		case unicode.IsSpace(r) || r == '-' || r == '_' || r == '.':
+			if b.Len() > 0 && !prevHyphen {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > MaxTenantSlugLen {
+		out = strings.Trim(out[:MaxTenantSlugLen], "-")
+	}
+	return out
+}
+
+// TenantSlugCandidate returns the slug for attempt n (1-based).
+// attempt 1 is the base; attempt 2+ appends "-{n}" (truncated so total length ≤ MaxTenantSlugLen).
+func TenantSlugCandidate(base string, attempt int) string {
+	base = strings.Trim(strings.ToLower(strings.TrimSpace(base)), "-")
+	if base == "" {
+		base = "tenant"
+	}
+	if attempt <= 1 {
+		if len(base) > MaxTenantSlugLen {
+			return strings.Trim(base[:MaxTenantSlugLen], "-")
+		}
+		return base
+	}
+	suffix := fmt.Sprintf("-%d", attempt)
+	maxBase := MaxTenantSlugLen - len(suffix)
+	if maxBase < 1 {
+		maxBase = 1
+	}
+	trimmed := base
+	if len(trimmed) > maxBase {
+		trimmed = strings.Trim(trimmed[:maxBase], "-")
+	}
+	if trimmed == "" {
+		trimmed = "tenant"
+		if len(trimmed) > maxBase {
+			trimmed = trimmed[:maxBase]
+		}
+	}
+	return trimmed + suffix
+}
+
+func foldLatinRune(r rune) rune {
+	switch r {
+	case 'á', 'à', 'ä', 'â', 'ã', 'å':
+		return 'a'
+	case 'é', 'è', 'ë', 'ê':
+		return 'e'
+	case 'í', 'ì', 'ï', 'î':
+		return 'i'
+	case 'ó', 'ò', 'ö', 'ô', 'õ':
+		return 'o'
+	case 'ú', 'ù', 'ü', 'û':
+		return 'u'
+	case 'ñ':
+		return 'n'
+	case 'ç':
+		return 'c'
+	default:
+		return r
+	}
+}

--- a/internal/services/tenantsignup/slug_test.go
+++ b/internal/services/tenantsignup/slug_test.go
@@ -1,0 +1,42 @@
+package tenantsignup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlugifyTenantName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "spaces to hyphens", in: "Panadería Sol", want: "panaderia-sol"},
+		{name: "already slug", in: "acme", want: "acme"},
+		{name: "trim and collapse", in: "  Hello   World!! ", want: "hello-world"},
+		{name: "empty", in: "   ", want: ""},
+		{name: "punctuation stripped", in: "Café & Pasteles", want: "cafe-pasteles"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SlugifyTenantName(tt.in))
+		})
+	}
+}
+
+func TestTenantSlugCandidate(t *testing.T) {
+	assert.Equal(t, "panaderia-sol", TenantSlugCandidate("panaderia-sol", 1))
+	assert.Equal(t, "panaderia-sol-2", TenantSlugCandidate("panaderia-sol", 2))
+	assert.Equal(t, "panaderia-sol-3", TenantSlugCandidate("panaderia-sol", 3))
+	assert.Equal(t, "tenant", TenantSlugCandidate("", 1))
+	assert.Equal(t, "tenant-2", TenantSlugCandidate("", 2))
+
+	long := strings.Repeat("a", 70)
+	got := TenantSlugCandidate(long, 1)
+	assert.LessOrEqual(t, len(got), MaxTenantSlugLen)
+	got2 := TenantSlugCandidate(long, 2)
+	assert.LessOrEqual(t, len(got2), MaxTenantSlugLen)
+	assert.True(t, strings.HasSuffix(got2, "-2"))
+}

--- a/model/auth/tenant_signup.go
+++ b/model/auth/tenant_signup.go
@@ -17,7 +17,9 @@ type CreateSignupCodeResponse struct {
 }
 
 type PublicTenantRegisterRequest struct {
-	TenantName  string `json:"tenant_name"`
+	TenantName string `json:"tenant_name"`
+	// TenantSlug is optional. When empty, the backend derives it from tenant_name
+	// and may append -2, -3, ... if the base slug is already taken.
 	TenantSlug  string `json:"tenant_slug"`
 	AdminName   string `json:"admin_name"`
 	Email       string `json:"email"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes tenant creation and slug assignment on the public signup path, which affects how new tenants are identified in URLs and routing.
> 
> **Overview**
> Public tenant registration no longer requires `tenant_slug`. When it is omitted, the API derives a URL-safe slug from `tenant_name` (lowercase, hyphens, basic Latin folding) and returns the slug actually used in the success response.
> 
> If the base slug is already taken, registration retries with suffixed candidates (`-2`, `-3`, …) up to 50 attempts instead of failing immediately. After all attempts fail, the client gets **409** with a business-name availability message; underivable names yield **400**.
> 
> New helpers live in `internal/services/tenantsignup/slug.go`; handler and model docs reflect optional slug behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4da29a708d1aafc137696f389a6a5b7d4e9a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->