### PR TITLE
removing slug reading

### DIFF
--- a/cmd/ai/main.go
+++ b/cmd/ai/main.go
@@ -8,7 +8,8 @@
 //	go run ./cmd/ai review -dry-run
 //	go run ./cmd/ai review -save
 //
-// Env overrides: OLLAMA_HOST (default http://localhost:11434), OLLAMA_MODEL (default qwen3:8b).
+// Env overrides: OLLAMA_HOST (default http://localhost:11434), OLLAMA_MODEL (default qwen3:8b),
+// OLLAMA_NUM_CTX (default 32768 — needed because Ollama's runtime default is often 4096).
 package main
 
 import (
@@ -100,6 +101,8 @@ func runReview(args []string) error {
 
 	fmt.Fprintf(os.Stderr, "diff: %s (%d bytes)\n", diffLabel, len(diff))
 	fmt.Fprintf(os.Stderr, "model: %s @ %s\n", *model, *host)
+	fmt.Fprintf(os.Stderr, "num_ctx: %d (override with OLLAMA_NUM_CTX)\n", ollamaNumCtx())
+	fmt.Fprintf(os.Stderr, "prompt: ~%d chars (~%d tokens est.)\n", len(prompt.combined()), len(prompt.combined())/4)
 
 	if *dryRun {
 		fmt.Println(prompt.combined())

--- a/cmd/ai/ollama.go
+++ b/cmd/ai/ollama.go
@@ -6,13 +6,21 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
+// defaultNumCtx is large enough for architecture + checklist + a typical working-tree
+// diff. Ollama's runtime default is often 4096, which silently truncates the middle
+// of the prompt (where the git diff lives) and makes the model claim "no diff".
+const defaultNumCtx = 32768
+
 type ollamaChatRequest struct {
 	Model    string          `json:"model"`
 	Stream   bool            `json:"stream"`
+	Think    bool            `json:"think"`
 	Messages []ollamaMessage `json:"messages"`
 	Options  map[string]any  `json:"options,omitempty"`
 }
@@ -27,21 +35,43 @@ type ollamaChatResponse struct {
 	Error   string        `json:"error,omitempty"`
 }
 
-func callOllama(host, model string, prompt reviewPrompt) (string, error) {
-	host = strings.TrimRight(host, "/")
-	url := host + "/api/chat"
+func ollamaNumCtx() int {
+	raw := strings.TrimSpace(os.Getenv("OLLAMA_NUM_CTX"))
+	if raw == "" {
+		return defaultNumCtx
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultNumCtx
+	}
+	return n
+}
 
-	body, err := json.Marshal(ollamaChatRequest{
+func buildOllamaChatRequest(model string, prompt reviewPrompt, numCtx int) ollamaChatRequest {
+	if numCtx <= 0 {
+		numCtx = defaultNumCtx
+	}
+	return ollamaChatRequest{
 		Model:  model,
 		Stream: false,
+		// Qwen3 thinking burns context and is unnecessary for structured reviews.
+		Think: false,
 		Messages: []ollamaMessage{
 			{Role: "system", Content: prompt.System},
 			{Role: "user", Content: prompt.User},
 		},
 		Options: map[string]any{
 			"temperature": 0.1,
+			"num_ctx":     numCtx,
 		},
-	})
+	}
+}
+
+func callOllama(host, model string, prompt reviewPrompt) (string, error) {
+	host = strings.TrimRight(host, "/")
+	url := host + "/api/chat"
+
+	body, err := json.Marshal(buildOllamaChatRequest(model, prompt, ollamaNumCtx()))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/ai/ollama_test.go
+++ b/cmd/ai/ollama_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildOllamaChatRequest_SetsNumCtxAndDisablesThink(t *testing.T) {
+	req := buildOllamaChatRequest("qwen3:8b", reviewPrompt{
+		System: "system",
+		User:   "user with a diff",
+	}, 32768)
+
+	assert.Equal(t, "qwen3:8b", req.Model)
+	assert.False(t, req.Stream)
+	assert.False(t, req.Think)
+	require.Len(t, req.Messages, 2)
+	assert.Equal(t, "system", req.Messages[0].Role)
+	assert.Equal(t, "user", req.Messages[1].Role)
+	assert.Equal(t, 0.1, req.Options["temperature"])
+	assert.Equal(t, 32768, req.Options["num_ctx"])
+
+	raw, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"num_ctx":32768`)
+	assert.Contains(t, string(raw), `"think":false`)
+}
+
+func TestDefaultNumCtx_IsLargeEnoughForReviewPrompts(t *testing.T) {
+	// Ollama defaults to 4096 on most machines; review prompts are typically 6–12k tokens.
+	assert.GreaterOrEqual(t, defaultNumCtx, 16384)
+}

--- a/cmd/ai/prompt.go
+++ b/cmd/ai/prompt.go
@@ -47,17 +47,11 @@ func buildReviewPrompt(root, diff string) (reviewPrompt, error) {
 		}
 	}
 	user.WriteString("\n")
-	user.WriteString("# GIT DIFF TO REVIEW\n\n")
-	user.WriteString("```diff\n")
-	user.WriteString(diff)
-	if !strings.HasSuffix(diff, "\n") {
-		user.WriteByte('\n')
-	}
-	user.WriteString("```\n\n")
 	user.WriteString("# TASK\n")
-	user.WriteString("Review the git diff against the guidelines above.\n")
+	user.WriteString("Review the git diff below against the guidelines above.\n")
 	user.WriteString("Only flag issues with clear evidence in the diff.\n")
-	user.WriteString("Do not invent files, tools, or generic security TODOs.\n\n")
+	user.WriteString("Do not invent files, tools, or generic security TODOs.\n")
+	user.WriteString("If the diff section is missing or empty, Verdict must be WARN and Summary must say the diff was missing.\n\n")
 	user.WriteString("Severity:\n")
 	user.WriteString("- BLOCK = clear architecture/security/data violation\n")
 	user.WriteString("- WARN = likely issue or missing tests/migrations\n")
@@ -76,6 +70,14 @@ func buildReviewPrompt(root, diff string) (reviewPrompt, error) {
 	user.WriteString("1. Concrete fix for a finding above (must reference an ALLOWED PATH)\n")
 	user.WriteString("or\n")
 	user.WriteString("none\n\n")
+	// Keep the diff last so it survives Ollama's start+end truncation if num_ctx is too small.
+	user.WriteString("# GIT DIFF TO REVIEW\n\n")
+	user.WriteString("```diff\n")
+	user.WriteString(diff)
+	if !strings.HasSuffix(diff, "\n") {
+		user.WriteByte('\n')
+	}
+	user.WriteString("```\n\n")
 	user.WriteString("Begin now with ## Verdict\n")
 
 	return reviewPrompt{

--- a/docs/FRONTEND_PRODUCT_API_CHANGES.md
+++ b/docs/FRONTEND_PRODUCT_API_CHANGES.md
@@ -1,0 +1,372 @@
+# Frontend changelog — Product flow hardening
+
+Backend changes the frontend must adopt. Use this as the migration checklist for catalog, admin product management, and checkout.
+
+---
+
+## Summary for FE
+
+| Area | What changed |
+|------|----------------|
+| Product field `available` | **Removed.** Do not send or read it. |
+| Product field `track_inventory` | **Added.** Controls whether stock is enforced. |
+| Public catalog | Only returns `status: "active"` products. |
+| Admin catalog | New authenticated endpoints return **all** statuses. |
+| Create product | Returns **201**; validation stricter; images still separate. |
+| Update product (`PUT`) | No longer accepts `image_urls` / `thumbnail_url`. |
+| Checkout / create order | New HTTP status mapping (404 / 409); duplicate line items merged server-side. |
+| Auth on product mutations | Admin or superadmin JWT required (403 otherwise). |
+| Tenant context | Required; missing tenant → **400** `tenant context required`. |
+
+---
+
+## 1. Product model (API shape)
+
+### Removed
+
+```json
+"available": true
+```
+
+Delete any toggle, type field, form control, or filter based on `available`.
+
+### Added
+
+```json
+"track_inventory": true
+```
+
+| Value | Meaning for UI |
+|-------|----------------|
+| `true` (default) | Stock is tracked. Show stock field; block buy / show “Agotado” when `stock === 0`. |
+| `false` | Unlimited inventory. Stock is ignored for purchase. Hide or disable stock as a purchase gate; optional to still show stock for internal notes. |
+
+### Unchanged (but now enforced)
+
+```json
+"status": "active" | "inactive" | "deleted"
+"stock": 0
+```
+
+| `status` | Public storefront | Purchasable | Admin |
+|----------|-------------------|-------------|--------|
+| `active` | Visible | Yes (if stock allows) | Manage |
+| `inactive` | Hidden | No | Keep / reactivate |
+| `deleted` | Hidden | No | Soft-deleted |
+
+### Example product JSON (response)
+
+```json
+{
+  "id_product": 12,
+  "tenant_id": 1,
+  "name": "Brownie",
+  "description": "Clásico",
+  "price": 3.5,
+  "track_inventory": true,
+  "stock": 8,
+  "status": "active",
+  "image_urls": ["https://res.cloudinary.com/.../main.jpg"],
+  "thumbnail_url": "https://res.cloudinary.com/.../main.jpg",
+  "created_on": "2026-07-23T10:00:00Z"
+}
+```
+
+---
+
+## 2. Public catalog (customer-facing)
+
+### Endpoints
+
+- `GET /t/{tenant_slug}/products`
+- `GET /t/{tenant_slug}/products/{id}`
+- Legacy `GET /products` / `GET /products/{id}` (prefer tenant path)
+
+### Behavior changes
+
+1. **List / get only return `status === "active"`.**
+   - Inactive / deleted products no longer appear.
+   - `GET .../products/{id}` for inactive/deleted → **404** `Product not found`.
+2. Still supports pagination: `limit`, `cursor`, optional `q` (name contains, min 2 chars).
+3. Tenant must be resolved (path slug or middleware). Missing tenant → **400**.
+
+### FE actions
+
+- Stop filtering by `available` on the client.
+- For buy button / cart:
+  - If `track_inventory === false` → always allow add-to-cart (while product is shown).
+  - If `track_inventory === true` and `stock === 0` → show sold out; do not add to cart.
+  - Prefer showing sold-out on active products rather than hiding them (backend still lists `stock: 0` active products).
+
+---
+
+## 3. Admin product endpoints (authenticated)
+
+All under `/auth/...` with:
+
+- `Authorization: Bearer <jwt>`
+- Tenant middleware (JWT tenant / path as today)
+- **Role: admin (`role_id = 1`) or superadmin (`role_id = 3`)**  
+  Client role → **403 Forbidden**
+
+### New / clarified reads (all statuses)
+
+| Method | Path | Behavior |
+|--------|------|----------|
+| `GET` | `/auth/products` | List products for the tenant (**all statuses**: active, inactive, deleted). Same pagination query params as public list. |
+| `GET` | `/auth/products/{id}` | Get one product **regardless of status**. |
+
+Use these for the admin catalog UI. Do **not** use public `GET /t/.../products` to manage inactive/deleted items.
+
+### Create
+
+`POST /auth/products`
+
+**Body (JSON):**
+
+```json
+{
+  "name": "Brownie",
+  "description": "Clásico",
+  "price": 3.5,
+  "stock": 10,
+  "track_inventory": true,
+  "status": "active"
+}
+```
+
+| Field | Rules |
+|-------|--------|
+| `name` | Required, non-empty |
+| `description` | Required, non-empty |
+| `price` | Required conceptually; must be `>= 0` (free products allowed) |
+| `stock` | Optional; default `0` |
+| `track_inventory` | Optional; **omit or null → `true`** |
+| `status` | Optional; omit → `"active"`. Must be `active` \| `inactive` \| `deleted` |
+| `available` | **Do not send** |
+| `image_urls` | **Do not send** on create — gallery starts empty |
+
+**Success:** **201 Created**
+
+```json
+{
+  "message": "Product created successfully",
+  "product_id": 12,
+  "image_urls": []
+}
+```
+
+After create, upload images via image endpoints (below).
+
+### Update fields
+
+`PUT /auth/products/{id}`
+
+**Body (JSON):**
+
+```json
+{
+  "name": "Brownie",
+  "description": "Clásico",
+  "price": 3.5,
+  "stock": 10,
+  "track_inventory": true,
+  "status": "active"
+}
+```
+
+| Field | Notes |
+|-------|--------|
+| `name`, `description` | Required |
+| `price` | `>= 0` |
+| `track_inventory` | Optional pointer: **omit keeps current value**. Send `true`/`false` to change. |
+| `status` | Optional: omit keeps current. |
+| `image_urls` | **Removed from this contract — ignored / not accepted for gallery updates** |
+| `thumbnail_url` | **Not on this PUT** — use thumbnail endpoints |
+| `available` | **Removed** |
+
+**Success:** 200
+
+### Soft delete / pause
+
+`PATCH /auth/products/{id}`
+
+```json
+{ "status": "inactive" }
+```
+
+or
+
+```json
+{ "status": "deleted" }
+```
+
+| Status | FE use |
+|--------|--------|
+| `inactive` | Pause without deleting (hide from storefront) |
+| `deleted` | Soft delete |
+| `active` | Publish / restore |
+
+On `deleted`, backend best-effort cleans local image files. Cloudinary URLs may still exist until purged separately; UI should treat product as gone from storefront immediately.
+
+### Images & thumbnails (unchanged routes, still the only gallery path)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/auth/products/{id}/images` | Add images (`multipart`, field `images`) |
+| `PUT` | `/auth/products/{id}/images` | Replace all images (`multipart`, field `images`) |
+| `DELETE` | `/auth/products/{id}/images?imageUrl=...` | Delete one image |
+| `PATCH` | `/auth/products/{id}/thumbnail` | Set thumbnail URL (must already be in `image_urls`) |
+| `POST` | `/auth/products/{id}/thumbnail` | Upload dedicated thumbnail (`multipart`, field `thumbnail`) |
+
+**Limits:** max **5MB** per image/thumbnail; types jpeg/jpg/png/webp.
+
+**Do not** send gallery URLs on `PUT /auth/products/{id}` — that never persisted and is no longer part of the update model.
+
+---
+
+## 4. Suggested admin UI controls
+
+Replace the old “Available” toggle with:
+
+1. **Status** — Active / Inactive / Deleted (or soft-delete action)
+2. **Track inventory** — checkbox/switch (“Limitar stock online”)
+3. **Stock** — number input; enabled mainly when track inventory is on
+
+Mental model for merchants:
+
+- Pause selling without deleting → `inactive`
+- Sold out but still listed → `active` + `track_inventory: true` + `stock: 0`
+- Don’t want to babysit stock → `track_inventory: false`
+
+---
+
+## 5. Create order (checkout)
+
+### Endpoints
+
+- Prefer: `POST /t/{tenant_slug}/orders`
+- Legacy: `POST /orders` (still needs tenant in context; prefer path-based)
+
+### Purchase rules (server-enforced)
+
+A line item succeeds only if:
+
+```text
+product exists for tenant
+AND status == "active"
+AND (track_inventory == false OR stock >= quantity)
+```
+
+Duplicate `id_product` lines in the same payload are **merged** (quantities summed) before stock checks.
+
+### HTTP status changes (important)
+
+| Situation | Old (typical) | New |
+|-----------|---------------|-----|
+| Product missing | Often 500 | **404** |
+| Product inactive / deleted | Often 500 / still buyable | **409** `product not available for purchase` |
+| Not enough stock | Often 500 | **409** `not enough product stock` |
+| Missing tenant | Silent tenant `1` | **400** `tenant context required` |
+| Success | 200 | 200 (unchanged) |
+
+### FE actions
+
+- Map **409** to user-friendly messages (sold out / product unavailable).
+- Map **404** to “product no longer available”.
+- Refresh cart / catalog after 409.
+- Stop relying on `available` for checkout eligibility.
+- Optional client-side pre-check using `status` + `track_inventory` + `stock` to reduce 409s.
+
+### Order status update (admin cancel)
+
+Cancelling an already cancelled / expired order is rejected (invalid transition). Stock is reverted once, only for products with `track_inventory: true`.
+
+---
+
+## 6. Auth & tenant checklist
+
+1. Product **mutations** and **admin product reads** (`/auth/products*`) need admin/superadmin token.
+2. Always send requests in a tenant-scoped way (`/t/{slug}/...` or authenticated tenant context). Do not assume default tenant `1`.
+3. Client-role users must not call admin product APIs (expect 403).
+
+---
+
+## 7. Types / codegen notes
+
+Suggested TypeScript shape:
+
+```ts
+type ProductStatus = "active" | "inactive" | "deleted";
+
+interface Product {
+  id_product: number;
+  tenant_id: number;
+  name: string;
+  description: string;
+  price: number;
+  track_inventory: boolean;
+  stock: number;
+  status: ProductStatus;
+  image_urls: string[];
+  thumbnail_url: string;
+  created_on?: string | null;
+}
+
+interface CreateProductRequest {
+  name: string;
+  description: string;
+  price: number;
+  stock?: number;
+  track_inventory?: boolean; // omit => true on server
+  status?: ProductStatus;    // omit => "active"
+}
+
+interface UpdateProductRequest {
+  name: string;
+  description: string;
+  price: number;
+  stock: number;
+  track_inventory?: boolean; // omit => keep existing
+  status?: ProductStatus;    // omit => keep existing
+}
+```
+
+Remove `available` from all Product types and forms.
+
+Helpers:
+
+```ts
+function isPurchasable(p: Product): boolean {
+  if (p.status !== "active") return false;
+  if (!p.track_inventory) return true;
+  return p.stock > 0;
+}
+
+function isSoldOut(p: Product): boolean {
+  return p.status === "active" && p.track_inventory && p.stock === 0;
+}
+```
+
+---
+
+## 8. Migration checklist (FE)
+
+- [ ] Remove `available` from types, forms, filters, and API payloads
+- [ ] Add `track_inventory` to product form (default ON)
+- [ ] Admin: use `GET /auth/products` (+ optional `GET /auth/products/{id}`) for management
+- [ ] Storefront: use public tenant product endpoints only
+- [ ] Create product: expect **201**; upload images after create
+- [ ] Update product: stop sending `image_urls` / `thumbnail_url` on PUT
+- [ ] Soft delete / pause via `PATCH` status
+- [ ] Checkout: handle **404** and **409** from create order
+- [ ] Sold-out UI based on `track_inventory` + `stock`, not `available`
+- [ ] Ensure product admin calls use admin JWT (not client)
+
+---
+
+## 9. Out of scope / unchanged for FE
+
+- Image upload still multipart to the same image routes (Cloudinary URL or `/uploads/...` depending on backend env).
+- Order create success response shape unchanged (`{ "message": "Order created successfully" }`).
+- Soft-deleted products are not hard-deleted; pending orders are not auto-cancelled when a product is soft-deleted.

--- a/internal/handlers/auth/tenant_signup.go
+++ b/internal/handlers/auth/tenant_signup.go
@@ -91,11 +91,8 @@ func (h *TenantSignupHandler) RegisterTenantWithCode(w http.ResponseWriter, r *h
 		writeValidatorJSONError(w, err, "Invalid tenant name")
 		return
 	}
-	tenantSlug := strings.TrimSpace(strings.ToLower(req.TenantSlug))
-	if tenantSlug == "" {
-		tenantSlug = tenantSignupService.SlugifyTenantName(tenantName)
-	}
-	if tenantSlug == "" {
+	// Slug is always derived from tenant_name; any client-sent tenant_slug is ignored.
+	if tenantSignupService.SlugifyTenantName(tenantName) == "" {
 		http.Error(w, "Could not derive tenant slug from tenant name", http.StatusBadRequest)
 		return
 	}
@@ -117,7 +114,6 @@ func (h *TenantSignupHandler) RegisterTenantWithCode(w http.ResponseWriter, r *h
 	}
 
 	req.TenantName = tenantName
-	req.TenantSlug = tenantSlug
 	resp, err := h.Service.RegisterTenantWithCode(r.Context(), req)
 	if err != nil {
 		switch {

--- a/internal/handlers/auth/tenant_signup_test.go
+++ b/internal/handlers/auth/tenant_signup_test.go
@@ -158,7 +158,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "expires_at", "used_at", "revoked_at"}).
 			AddRow(uint64(5), time.Now().UTC().Add(2*time.Hour), nil, nil))
 	mock.ExpectQuery(`INSERT INTO tenants`).
-		WithArgs("Acme Bakery", "acme").
+		WithArgs("Acme Bakery", "acme-bakery").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uint64(10)))
 	mock.ExpectQuery(`INSERT INTO users`).
 		WithArgs(uint64(10), 1, "Owner Admin", "owner@acme.com", "555-0101", sqlmock.AnyArg()).
@@ -170,7 +170,6 @@ func TestTenantSignupHandler_RegisterTenantWithCode_Success(t *testing.T) {
 
 	body := bytes.NewBufferString(`{
 		"tenant_name":"Acme Bakery",
-		"tenant_slug":"acme",
 		"admin_name":"Owner Admin",
 		"email":"owner@acme.com",
 		"phone":"555-0101",
@@ -189,6 +188,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_Success(t *testing.T) {
 	assert.Equal(t, uint64(10), resp.TenantID)
 	assert.Equal(t, uint64(100), resp.AdminID)
 	assert.Equal(t, "Acme Bakery", resp.TenantName)
+	assert.Equal(t, "acme-bakery", resp.TenantSlug)
 	assert.NotEmpty(t, resp.Token)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -235,7 +235,6 @@ func TestTenantSignupHandler_CreateSignupCode_DefaultTTL120(t *testing.T) {
 func validRegisterBody(oneTimeCode string) string {
 	return `{
 		"tenant_name":"Acme Bakery",
-		"tenant_slug":"acme",
 		"admin_name":"Owner Admin",
 		"email":"owner@acme.com",
 		"phone":"555-0101",
@@ -362,7 +361,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithUnknownOTC_Returns422(t 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestTenantSignupHandler_RegisterTenantWithCode_WithoutSlug_DerivesFromName(t *testing.T) {
+func TestTenantSignupHandler_RegisterTenantWithCode_ProvidedSlug_IsIgnored(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close()
@@ -391,8 +390,10 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithoutSlug_DerivesFromName(
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
+	// Client-sent tenant_slug must be ignored; slug comes from tenant_name.
 	body := bytes.NewBufferString(`{
 		"tenant_name":"Acme Bakery",
+		"tenant_slug":"custom-client-slug",
 		"admin_name":"Owner Admin",
 		"email":"owner@acme.com",
 		"phone":"555-0101",
@@ -432,7 +433,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_AutoSuffix
 		WillReturnRows(sqlmock.NewRows([]string{"id", "expires_at", "used_at", "revoked_at"}).
 			AddRow(uint64(5), time.Now().UTC().Add(2*time.Hour), nil, nil))
 	mock.ExpectQuery(`INSERT INTO tenants`).
-		WithArgs("Acme Bakery", "acme").
+		WithArgs("Acme Bakery", "acme-bakery").
 		WillReturnError(&pq.Error{Code: "23505"})
 	mock.ExpectRollback()
 
@@ -442,7 +443,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_AutoSuffix
 		WillReturnRows(sqlmock.NewRows([]string{"id", "expires_at", "used_at", "revoked_at"}).
 			AddRow(uint64(5), time.Now().UTC().Add(2*time.Hour), nil, nil))
 	mock.ExpectQuery(`INSERT INTO tenants`).
-		WithArgs("Acme Bakery", "acme-2").
+		WithArgs("Acme Bakery", "acme-bakery-2").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uint64(10)))
 	mock.ExpectQuery(`INSERT INTO users`).
 		WithArgs(uint64(10), 1, "Owner Admin", "owner@acme.com", "555-0101", sqlmock.AnyArg()).
@@ -462,7 +463,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateSlug_AutoSuffix
 	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
 	var resp authModel.PublicTenantRegisterResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	assert.Equal(t, "acme-2", resp.TenantSlug)
+	assert.Equal(t, "acme-bakery-2", resp.TenantSlug)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -483,7 +484,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithDuplicateAdminEmail_Retu
 		WillReturnRows(sqlmock.NewRows([]string{"id", "expires_at", "used_at", "revoked_at"}).
 			AddRow(uint64(5), time.Now().UTC().Add(2*time.Hour), nil, nil))
 	mock.ExpectQuery(`INSERT INTO tenants`).
-		WithArgs("Acme Bakery", "acme").
+		WithArgs("Acme Bakery", "acme-bakery").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uint64(10)))
 	mock.ExpectQuery(`INSERT INTO users`).
 		WithArgs(uint64(10), 1, "Owner Admin", "owner@acme.com", "555-0101", sqlmock.AnyArg()).
@@ -524,7 +525,7 @@ func TestTenantSignupHandler_RegisterTenantWithCode_WithRaceOnSameOTC_OnlyOneSuc
 		WillReturnRows(sqlmock.NewRows([]string{"id", "expires_at", "used_at", "revoked_at"}).
 			AddRow(uint64(5), time.Now().UTC().Add(2*time.Hour), nil, nil))
 	mock.ExpectQuery(`INSERT INTO tenants`).
-		WithArgs("Acme Bakery", "acme").
+		WithArgs("Acme Bakery", "acme-bakery").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uint64(10)))
 	mock.ExpectQuery(`INSERT INTO users`).
 		WithArgs(uint64(10), 1, "Owner Admin", "owner@acme.com", "555-0101", sqlmock.AnyArg()).

--- a/internal/services/tenantsignup/service.go
+++ b/internal/services/tenantsignup/service.go
@@ -106,10 +106,8 @@ func (s *TenantSignupService) RegisterTenantWithCode(ctx context.Context, req au
 		return authModel.PublicTenantRegisterResponse{}, err
 	}
 
-	baseSlug := strings.TrimSpace(strings.ToLower(req.TenantSlug))
-	if baseSlug == "" {
-		baseSlug = SlugifyTenantName(req.TenantName)
-	}
+	// Always derive from tenant name; never accept a client-provided slug.
+	baseSlug := SlugifyTenantName(req.TenantName)
 	if baseSlug == "" {
 		return authModel.PublicTenantRegisterResponse{}, ErrInvalidTenantSlug
 	}

--- a/model/auth/tenant_signup.go
+++ b/model/auth/tenant_signup.go
@@ -16,11 +16,10 @@ type CreateSignupCodeResponse struct {
 	Message   string    `json:"message"`
 }
 
+// PublicTenantRegisterRequest is the body for POST /public/tenant-register.
+// Slug is derived from TenantName server-side; client-sent tenant_slug is ignored.
 type PublicTenantRegisterRequest struct {
-	TenantName string `json:"tenant_name"`
-	// TenantSlug is optional. When empty, the backend derives it from tenant_name
-	// and may append -2, -3, ... if the base slug is already taken.
-	TenantSlug  string `json:"tenant_slug"`
+	TenantName  string `json:"tenant_name"`
 	AdminName   string `json:"admin_name"`
 	Email       string `json:"email"`
 	Phone       string `json:"phone"`

--- a/run.sh
+++ b/run.sh
@@ -236,6 +236,12 @@ reset() {
 #   -host URL     Ollama base URL (default http://localhost:11434)
 #   -save         write review under .ai/reviews/ (already default via run.sh)
 #
+# Env:
+#   OLLAMA_NUM_CTX   context window for the review call (default 32768).
+#                    Ollama's own default is often 4096, which truncates the
+#                    git diff out of the prompt — raise this if reviews say
+#                    "no diff provided" despite a non-empty diff.
+#
 # Via ./run.sh, reviews are saved under .ai/reviews/ by default for all modes
 # except -dry-run. Pass flags as usual; -save is added automatically when missing.
 review() {

--- a/tests/tenant_signup_integration_test.go
+++ b/tests/tenant_signup_integration_test.go
@@ -162,7 +162,6 @@ func registerTenantPublic(
 	t *testing.T,
 	env *tenantSignupIntegrationEnv,
 	tenantName,
-	tenantSlug,
 	adminName,
 	email,
 	phone,
@@ -173,13 +172,12 @@ func registerTenantPublic(
 
 	payload := fmt.Sprintf(`{
 		"tenant_name":"%s",
-		"tenant_slug":"%s",
 		"admin_name":"%s",
 		"email":"%s",
 		"phone":"%s",
 		"password":"%s",
 		"one_time_code":"%s"
-	}`, tenantName, tenantSlug, adminName, email, phone, password, code)
+	}`, tenantName, adminName, email, phone, password, code)
 
 	req := httptest.NewRequest(http.MethodPost, "/public/tenant-register", bytes.NewBufferString(payload))
 	req.Header.Set("Content-Type", "application/json")
@@ -286,12 +284,11 @@ func TestTenantSignupIntegration_RegisterWithCode_HappyPath(t *testing.T) {
 	assert.Equal(t, 1, env.emailSender.calls)
 	assert.Contains(t, env.emailSender.last.RegisterURL, createdCode.Code)
 
-	slug := fmt.Sprintf("tenant-happy-%d", time.Now().UnixNano())
 	email := fmt.Sprintf("owner-happy-%d@test.com", time.Now().UnixNano())
 
 	rr := registerTenantPublic(
 		t, env,
-		"Tenant Happy", slug, "Owner Happy", email, "555-1010", "StrongPass123!",
+		"Tenant Happy", "Owner Happy", email, "555-1010", "StrongPass123!",
 		createdCode.Code,
 	)
 	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
@@ -299,7 +296,7 @@ func TestTenantSignupIntegration_RegisterWithCode_HappyPath(t *testing.T) {
 	var resp authModel.PublicTenantRegisterResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
 	assert.Equal(t, "Tenant registered successfully", resp.Message)
-	assert.Equal(t, slug, resp.TenantSlug)
+	assert.Equal(t, "tenant-happy", resp.TenantSlug)
 	assert.Equal(t, "Tenant Happy", resp.TenantName)
 	assert.Equal(t, email, resp.AdminEmail)
 	assert.NotEmpty(t, resp.Token)
@@ -341,20 +338,18 @@ func TestTenantSignupIntegration_RegisterWithCode_ReusedCodeReturns422(t *testin
 
 	createdCode := createSignupCodeInternal(t, env, "invitee-reuse@test.com", 120, "integration reused code")
 
-	firstSlug := fmt.Sprintf("tenant-reuse-a-%d", time.Now().UnixNano())
 	firstEmail := fmt.Sprintf("owner-reuse-a-%d@test.com", time.Now().UnixNano())
 	first := registerTenantPublic(
 		t, env,
-		"Tenant Reuse A", firstSlug, "Owner Reuse A", firstEmail, "555-2020", "StrongPass123!",
+		"Tenant Reuse A", "Owner Reuse A", firstEmail, "555-2020", "StrongPass123!",
 		createdCode.Code,
 	)
 	require.Equal(t, http.StatusCreated, first.Code, first.Body.String())
 
-	secondSlug := fmt.Sprintf("tenant-reuse-b-%d", time.Now().UnixNano())
 	secondEmail := fmt.Sprintf("owner-reuse-b-%d@test.com", time.Now().UnixNano())
 	second := registerTenantPublic(
 		t, env,
-		"Tenant Reuse B", secondSlug, "Owner Reuse B", secondEmail, "555-2021", "StrongPass123!",
+		"Tenant Reuse B", "Owner Reuse B", secondEmail, "555-2021", "StrongPass123!",
 		createdCode.Code,
 	)
 	assert.Equal(t, http.StatusUnprocessableEntity, second.Code, second.Body.String())
@@ -368,11 +363,10 @@ func TestTenantSignupIntegration_RegisterWithCode_ExpiredCodeReturns422(t *testi
 	expiredCode := "EXPIRED1-CODE0001"
 	insertSignupCodeForTest(t, env.db, expiredCode, time.Now().UTC().Add(-5*time.Minute), false)
 
-	slug := fmt.Sprintf("tenant-expired-%d", time.Now().UnixNano())
 	email := fmt.Sprintf("owner-expired-%d@test.com", time.Now().UnixNano())
 	rr := registerTenantPublic(
 		t, env,
-		"Tenant Expired", slug, "Owner Expired", email, "555-3030", "StrongPass123!",
+		"Tenant Expired", "Owner Expired", email, "555-3030", "StrongPass123!",
 		expiredCode,
 	)
 
@@ -387,11 +381,10 @@ func TestTenantSignupIntegration_RegisterWithCode_RevokedCodeReturns422(t *testi
 	revokedCode := "REVOKED1-CODE0002"
 	insertSignupCodeForTest(t, env.db, revokedCode, time.Now().UTC().Add(2*time.Hour), true)
 
-	slug := fmt.Sprintf("tenant-revoked-%d", time.Now().UnixNano())
 	email := fmt.Sprintf("owner-revoked-%d@test.com", time.Now().UnixNano())
 	rr := registerTenantPublic(
 		t, env,
-		"Tenant Revoked", slug, "Owner Revoked", email, "555-4040", "StrongPass123!",
+		"Tenant Revoked", "Owner Revoked", email, "555-4040", "StrongPass123!",
 		revokedCode,
 	)
 
@@ -403,12 +396,12 @@ func TestTenantSignupIntegration_RegisterWithCode_DuplicateSlugAutoSuffixes(t *t
 	env, cleanup := setupTenantSignupIntegrationEnv(t)
 	defer cleanup()
 
-	// Seeded tenant uses slug "default"; requesting the same slug should succeed as "default-2".
+	// Seeded tenant uses slug "default"; a name that slugifies to "default" should succeed as "default-2".
 	createdCode := createSignupCodeInternal(t, env, "invitee-dup-slug@test.com", 120, "integration duplicate slug")
 	ownerEmail := fmt.Sprintf("owner-collision-%d@test.com", time.Now().UnixNano())
 	rr := registerTenantPublic(
 		t, env,
-		"Default Tenant Collision", "default", "Owner Collision", ownerEmail, "555-5050", "StrongPass123!",
+		"Default", "Owner Collision", ownerEmail, "555-5050", "StrongPass123!",
 		createdCode.Code,
 	)
 
@@ -451,12 +444,10 @@ func TestTenantSignupIntegration_RegisterWithCode_ConcurrentSameCodeOnlyOneSucce
 		defer wg.Done()
 		<-start
 
-		slug := fmt.Sprintf("tenant-race-%s-%d", suffix, time.Now().UnixNano())
 		email := fmt.Sprintf("owner-race-%s-%d@test.com", suffix, time.Now().UnixNano())
 		rr := registerTenantPublic(
 			t, env,
 			"Tenant Race "+suffix,
-			slug,
 			"Owner Race "+suffix,
 			email,
 			"555-6060",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Signup API contract change may break clients that relied on choosing their slug; behavior is intentional but needs frontend coordination.
> 
> **Overview**
> **Public tenant registration** no longer accepts or honors a client `tenant_slug`. The slug is always computed from `tenant_name` via `SlugifyTenantName`, with the existing `-2`, `-3`, … collision handling unchanged.
> 
> The request model drops `tenant_slug`; handler and `RegisterTenantWithCode` service logic were aligned so optional slug override is removed end-to-end. Unit and integration tests now assert derived slugs (e.g. `acme-bakery`) and that a sent `tenant_slug` is ignored.
> 
> Separately, **`cmd/ai review`** documents `OLLAMA_NUM_CTX` (default 32768) and logs `num_ctx` plus estimated prompt size before calling Ollama.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9fa7f653ea4d8153040367ecdc353c5a27fa61e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->