### PR TITLE
hardening orders flow

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -486,7 +486,9 @@ func main() {
 	legacyPublic.Use(middleware.TenantFromPathOrHeader(tenantRepo))
 	legacyPublic.HandleFunc("/products", productHandler.GetAllProducts).Methods("GET")
 	legacyPublic.HandleFunc("/products/{id}", productHandler.GetProductByID).Methods("GET")
-	legacyPublic.HandleFunc("/orders", orderHandler.CreateOrder).Methods("POST")
+	legacyOrders := legacyPublic.PathPrefix("").Subrouter()
+	legacyOrders.Use(middleware.RequireOperableSubscription(tenantRepo))
+	legacyOrders.HandleFunc("/orders", orderHandler.CreateOrder).Methods("POST")
 
 	r.HandleFunc("/setup/bootstrap/tenant", bootstrapHandler.BootstrapTenant).Methods("POST")
 	r.HandleFunc("/public/tenant-register", tenantSignupHandler.RegisterTenantWithCode).Methods("POST")
@@ -520,7 +522,7 @@ func main() {
 		fmt.Fprint(w, "Token válido, acceso permitido")
 	}).Methods("GET")
 
-	// Product reads (all statuses) + mutations require admin or superadmin.
+	// Product reads (all statuses) + mutations + order management require admin or superadmin.
 	authAdmin := auth.PathPrefix("").Subrouter()
 	authAdmin.Use(middleware.RequireAdminRole())
 	authAdmin.HandleFunc("/products", productHandler.GetAllProductsAdmin).Methods("GET")
@@ -534,10 +536,10 @@ func main() {
 	authAdmin.HandleFunc("/products/{id}/images", imageHandler.ReplaceProductImages).Methods("PUT")
 	authAdmin.HandleFunc("/products/{id}/images", imageHandler.DeleteProductImage).Methods("DELETE")
 
-	// Order endpoints (authenticated: list, get, update)
-	auth.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
-	auth.HandleFunc("/orders/{id}", orderHandler.GetOrderByID).Methods("GET")
-	auth.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
+	// Order endpoints (admin only: list, get, update)
+	authAdmin.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
+	authAdmin.HandleFunc("/orders/{id}", orderHandler.GetOrderByID).Methods("GET")
+	authAdmin.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
 
 	// Tenant branding: reads are public (see tPublic); mutations require auth
 	auth.HandleFunc("/branding/logo", tenantHandler.UploadTenantLogo).Methods("PATCH")
@@ -564,7 +566,9 @@ func main() {
 	tPublic.HandleFunc("/products", productHandler.GetAllProducts).Methods("GET")
 	tPublic.HandleFunc("/products/{id}", productHandler.GetProductByID).Methods("GET")
 	tPublic.HandleFunc("/branding", tenantHandler.GetBranding).Methods("GET")
-	tPublic.HandleFunc("/orders", orderHandler.CreateOrder).Methods("POST")
+	tPublicOrders := tPublic.PathPrefix("").Subrouter()
+	tPublicOrders.Use(middleware.RequireOperableSubscription(tenantRepo))
+	tPublicOrders.HandleFunc("/orders", orderHandler.CreateOrder).Methods("POST")
 
 	// Wrap router with CORS
 	corsWrapped := handlers.CORS(allowedOrigins, allowedMethods, allowedHeaders, allowCredentials)(r)

--- a/docs/FRONTEND_ORDERS_API_CHANGES.md
+++ b/docs/FRONTEND_ORDERS_API_CHANGES.md
@@ -1,0 +1,145 @@
+# Frontend changelog — Orders flow hardening
+
+Backend changes the frontend must adopt for checkout and admin order management.
+
+---
+
+## Summary
+
+| Area | What changed |
+|------|----------------|
+| `/auth/orders*` | **Admin / superadmin only** (client JWT → **403**) |
+| Status workflow | **Linear only:** `pending → preparing → ready → delivered` |
+| Cancel | Only from `pending` / `preparing` / `ready` — **not** from `delivered` |
+| Soft-delete | Only from `cancelled` / `expired` / `delivered` — never touches stock |
+| Stock restore | On cancel (pre-delivery) and ghost `expired`; never after `delivered` |
+| Subscription canceled | Public create → **404**; auth orders → **403** |
+| Create success | **201** + `{ "message", "id_order" }` |
+| Delivery date | **Today allowed** (calendar day ≥ today) |
+
+---
+
+## 1. Auth — who can call `/auth/orders*`
+
+| Method | Path | Who |
+|--------|------|-----|
+| `GET` | `/auth/orders` | Admin / superadmin |
+| `GET` | `/auth/orders/{id}` | Admin / superadmin |
+| `PATCH` | `/auth/orders/{id}` | Admin / superadmin |
+
+Client role → **403 Forbidden**.
+
+Storefront checkout stays public (`POST /t/{slug}/orders` or legacy `POST /orders` + `X-Tenant-Slug`) — no JWT.
+
+---
+
+## 2. Status workflow (admin PATCH)
+
+### Allowed
+
+```text
+pending → preparing → ready → delivered
+
+pending | preparing | ready → cancelled   (restores tracked stock)
+
+cancelled | expired | delivered → deleted   (no stock change)
+```
+
+### Rejected (400)
+
+- Skips (`pending → ready`, `pending → delivered`, …)
+- Backwards (`ready → preparing`, …)
+- `delivered → cancelled`
+- `pending → deleted` (and any delete before cancelled/expired/delivered)
+- Changes from `cancelled` / `expired` / `deleted` (except `→ deleted` from cancelled/expired)
+
+`expired` is set only by the ghost worker (unpaid timeout), not by PATCH.
+
+### Stock
+
+| Event | Tracked inventory |
+|-------|-------------------|
+| Create | Decrement |
+| Cancel (pre-delivery) | Restore |
+| Expire (worker) | Restore |
+| Delivered | Keep decremented (sale) |
+| Delete | No stock change |
+
+---
+
+## 3. Create order (public)
+
+### Endpoints
+
+- `POST /t/{tenant_slug}/orders` (preferred)
+- `POST /orders` + `X-Tenant-Slug` (legacy)
+
+### Success (new)
+
+**201 Created**
+
+```json
+{
+  "message": "Order created successfully",
+  "id_order": 42
+}
+```
+
+Use `id_order` for confirmation / deep links.
+
+### Delivery date
+
+- Format: `YYYY-MM-DD`
+- **Today is valid**
+- Past calendar days → 400
+
+### Subscription canceled
+
+Public create (path/header tenant resolution) returns **404**  
+`tenant not found or inactive` — same as other public tenant routes when subscription is `canceled`.
+
+Auth `/auth/orders*` with a canceled tenant returns **403**  
+`tenant subscription is canceled`.
+
+Do not allow checkout while the bakery is not paying.
+
+### Other create errors (unchanged mapping)
+
+| Case | HTTP |
+|------|------|
+| Validation | 400 |
+| Product not found | 404 |
+| Product not purchasable (inactive/deleted) | 409 |
+| Not enough stock | 409 |
+
+Duplicate `id_product` lines are still merged server-side.
+
+---
+
+## 4. Soft-delete vs cancel (admin UX)
+
+- **Cancel** = stop the order before delivery → inventory comes back (if tracked).
+- **Delete** = hide from default admin list **after** the order is already finished (`cancelled` / `expired` / `delivered`). No inventory side effects.
+
+Default `GET /auth/orders` still hides `deleted` unless `ignore_status=true` or `status=deleted`.
+
+---
+
+## 5. Migration checklist (FE)
+
+- [ ] Ensure admin order screens use **admin JWT** (not client)
+- [ ] Handle **403** on `/auth/orders*` for non-admin
+- [ ] Status UI: only next linear step + cancel (pre-delivery) + delete (terminal only)
+- [ ] Block cancel button on `delivered`
+- [ ] Block delete until cancelled / expired / delivered
+- [ ] Create order: expect **201** and read `id_order`
+- [ ] Allow selecting **today** as delivery date
+- [ ] Handle **404** on public create when subscription canceled (“store unavailable”)
+- [ ] Sold-out / 409 handling unchanged from product hardening
+
+---
+
+## 6. Out of scope (no FE work expected yet)
+
+- Customer self-service order portal
+- `GET /auth/orders/{id}/history` endpoint

--- a/docs/ORDERS_FLOW_AUDIT.md
+++ b/docs/ORDERS_FLOW_AUDIT.md
@@ -1,0 +1,520 @@
+# Orders flow audit + implementation plan
+
+Maps the current orders lifecycle, prioritizes headaches, and records the **locked decisions** for Critical / High hardening (including history write fixes).
+
+**Date context:** post product-flow hardening (`track_inventory`, active-only catalog, admin product gates).
+
+**Status:** decisions locked — ready to implement (sections 11–13). Sections 1–10 remain the pre-fix audit snapshot (“as is today”).
+
+---
+
+## Goals of this audit
+
+Answer, for orders:
+
+1. What does each status / field mean today?
+2. What actually gates create, list, update, cancel, expire?
+3. Where do stock, auth, and status rules fight each other?
+4. What is missing or inconsistent vs what a bakery tenant would expect?
+5. What will we change, and why?
+
+---
+
+## Mental model (current)
+
+```mermaid
+flowchart TB
+  subgraph Public
+    Create["POST /t/{slug}/orders\nor POST /orders + X-Tenant-Slug"]
+  end
+  subgraph Auth["GET/PATCH /auth/orders*"]
+    List[List / Get]
+    Patch[Update status / paid]
+  end
+  subgraph CreatePipe
+    User[Get-or-create client user]
+    Products[Load active products]
+    TxCreate["TX: lock → decrement tracked stock → order + items + history"]
+  end
+  subgraph PatchPipe
+    Terminal{From cancelled/expired?}
+    StockQ{Admin AND cancelled?}
+    TxPatch["TX: status ± paid ± stock revert + history"]
+  end
+  subgraph Worker
+    Ghost["Claim pending unpaid expires_at past → expired"]
+    Revert[Always revert tracked stock]
+  end
+
+  Create --> User --> Products --> TxCreate
+  List --> DB[(orders)]
+  Patch --> Terminal
+  Terminal -->|yes| Block[Reject]
+  Terminal -->|no| StockQ
+  StockQ -->|yes| TxPatch
+  StockQ -->|no status-only| TxPatch
+  Ghost --> Revert --> DB
+  TxCreate --> DB
+  TxPatch --> DB
+```
+
+---
+
+## 1. Endpoints map
+
+| Method | Path | Auth | Tenant | Role gate |
+|--------|------|------|--------|-----------|
+| `POST` | `/t/{tenant_slug}/orders` | None | Path slug | Public |
+| `POST` | `/orders` | None | `X-Tenant-Slug` (legacy) | Public |
+| `GET` | `/auth/orders` | JWT | JWT / middleware | **Any role** (not admin-only) |
+| `GET` | `/auth/orders/{id}` | JWT | JWT / middleware | **Any role** |
+| `PATCH` | `/auth/orders/{id}` | JWT | JWT / middleware | **Any role**; stock restore only if admin/superadmin on cancel |
+
+Contrast with products: product mutations use `RequireAdminRole`. Orders management does **not**.
+
+---
+
+## 2. Order statuses
+
+| Status | How it gets set | Visible in default list? | Stock |
+|--------|-----------------|--------------------------|--------|
+| `pending` | Create order | Yes | Reserved at create (if `track_inventory`) |
+| `preparing` | PATCH | Yes | Unchanged |
+| `ready` | PATCH | Yes | Unchanged |
+| `delivered` | PATCH | Yes | Unchanged |
+| `cancelled` | PATCH | Yes | Reverted **only if** caller is admin/superadmin |
+| `expired` | Ghost worker only | Yes | Always reverted by worker |
+| `deleted` | PATCH | **No** (unless `ignore_status=true` or `status=` filter) | **Never** reverted |
+
+### Transition rules (actual)
+
+Only these are enforced:
+
+- From `cancelled` → anything: blocked
+- From `expired` → anything: blocked
+- Everything else: **allowed**
+
+So today these are legal:
+
+- `pending → delivered` (skip kitchen steps)
+- `delivered → preparing` (backwards)
+- `delivered → cancelled` (admin) → **stock put back after fulfillment**
+- `pending → deleted` → **stock stays reserved forever** (unless product is unlimited)
+
+`ErrOrderAlreadyDelivered` exists in errors package but is **unused**.
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending: CreateOrder
+  pending --> preparing: PATCH
+  pending --> ready: PATCH
+  pending --> delivered: PATCH
+  pending --> cancelled: PATCH
+  pending --> deleted: PATCH
+  pending --> expired: GhostWorker
+  preparing --> ready: PATCH
+  preparing --> delivered: PATCH
+  preparing --> cancelled: PATCH
+  preparing --> deleted: PATCH
+  ready --> delivered: PATCH
+  ready --> cancelled: PATCH
+  ready --> deleted: PATCH
+  delivered --> preparing: PATCH
+  delivered --> cancelled: PATCH
+  delivered --> deleted: PATCH
+  cancelled --> [*]
+  expired --> [*]
+```
+
+---
+
+## 3. Happy paths
+
+### Create order
+
+1. Validate payload (name, email, phone, delivery_date, delivery_direction, items).
+2. Parse `delivery_date` as `YYYY-MM-DD`; reject if `Before(time.Now())`.
+3. Resolve tenant (path or header).
+4. Get-or-create **client** user by email (tenant-scoped).
+5. Merge duplicate `id_product` lines; load products; require `status == active`.
+6. Price total from current product prices; set `expires_at` from tenant ghost timeout (else env / 30 min).
+7. TX: lock products → decrement stock when `track_inventory` → insert order (`pending`, `paid=false`) → insert items with **name/price snapshots** → history (`create`, best-effort).
+8. Response: **200** `{ "message": "Order created successfully" }` — **no `id_order`**.
+
+Mapped errors:
+
+| Case | HTTP |
+|------|------|
+| Missing / invalid fields | 400 |
+| Product not found | 404 |
+| Inactive / deleted product | 409 |
+| Not enough stock | 409 |
+| Missing tenant | 400 |
+
+### List / get
+
+- Cursor pagination (`created_on ASC, id_order ASC`).
+- Filters: `ignore_status`, `status`, `id_user`, `q` (user name/email; numeric also matches `id_order`).
+- Default list hides `deleted`.
+- Joins items; returns snapshots as `name` / `unit_price`.
+
+### Update (`PATCH`)
+
+Body: at least one of `status`, `paid`; optional `cancellation_reason`.
+
+Allowed PATCH targets: `preparing | ready | delivered | cancelled | deleted`  
+(not `pending` or `expired` via API).
+
+- Status (+ optional paid) goes through status updater (TX when stock revert and/or paid).
+- Paid-only updates paid flag + history.
+- Admin cancel → stock revert; client cancel → status only.
+
+### Ghost / expired unpaid
+
+Background worker (interval from env, default 5 min):
+
+- Per active tenant, claim `pending` + unpaid + `expires_at < now` → `expired`
+- Revert tracked stock + write history (`modified_by = 0`, system cancellation reason)
+
+---
+
+## 4. Stock coupling (orders ↔ products)
+
+| Event | Tracked inventory | Unlimited (`track_inventory=false`) |
+|-------|-------------------|-------------------------------------|
+| Create | Decrement if enough | Skip |
+| Admin cancel | Revert qty | No-op |
+| Client cancel | **No revert** | N/A |
+| Expired worker | Revert qty | No-op |
+| Soft-delete order (`deleted`) | **No revert** | N/A |
+| Admin cancel from `delivered` | **Still reverts** | No-op |
+
+This is the main inventory headache: reservation at create is clear, but release rules are asymmetric and can overstock or leak stock.
+
+---
+
+## 5. Fields / snapshots
+
+| Field | Role |
+|-------|------|
+| `total_price` | Sum at create from live prices |
+| `product_name_snapshot` / `unit_price_snapshot` | Frozen on line items at create |
+| `paid` | Boolean; independent of status in practice |
+| `expires_at` | Ghost deadline snapshot |
+| `delivery_direction` | Required on create |
+| `delivery_date` | Required; date-only |
+| `note` | Optional |
+| `cancellation_reason` | Optional on cancel |
+
+After create there is **no API** to edit note, delivery date, or delivery direction.
+
+---
+
+## 6. Findings by severity
+
+### Critical
+
+1. **No admin role gate on `/auth/orders*`**  
+   Any JWT (including client) can list **all** tenant orders and PATCH status/paid/delete. Products are admin-gated; orders are not.
+
+2. **Admin cancel restores stock even from `delivered`**  
+   Weak transition rules + “cancel always reverts for admin” can inflate inventory after fulfillment.
+
+3. **Client cancel does not restore stock**  
+   Combined with (1), a client can cancel (or mark deleted) and leave stock reserved — inventory DoS / leak.
+
+### High
+
+4. **`status=deleted` never restores stock**  
+   Soft-hiding a pending order permanently locks reserved units (for tracked products).
+
+5. **Public create ignores subscription canceled**  
+   Auth management may be blocked, but storefront can still place orders if tenant is “active” at tenant-row level.
+
+6. **Same-day `delivery_date` often rejected**  
+   `deliveryDate.Before(time.Now())` compares midnight UTC/local parse vs wall clock → today frequently fails.
+
+7. **OpenAPI incomplete**  
+   Documents list mainly; create/get/patch, public routes, and status/stock rules are undocumented or incomplete.
+
+### High (also in scope)
+
+8. **Create response has no `id_order`** (and uses 200 not 201) — FE cannot deep-link or poll the new order easily. **(In scope: return `id_order`, prefer 201.)**
+9. **No real status FSM** — kitchen progression is cosmetic; `ErrOrderAlreadyDelivered` unused. **(In scope: linear FSM.)**
+10. **History incomplete fields** (elevated) — ghost/cancel history may omit fields such as `delivery_direction`; writes stay best-effort but payloads must be complete. **(In scope.)**
+
+### Medium (out of scope for this pass)
+
+11. **Soft-deleted user + same email** can break reorder (unique email) → opaque failure.
+12. **No rate limit** on public create; ghost worker does not run immediately on process start.
+13. **Existing customer name/phone** from payload not refreshed on reorder (email match only).
+14. **No HTTP API for order history** (repo method exists, no route) — not adding endpoint this pass.
+
+### Low (out of scope for this pass)
+
+15. Dead / legacy helpers (`GetExpiredPendingOrders` by `created_on` vs `expires_at` claim path).
+16. JSON `OrderItems` PascalCase vs snake_case elsewhere.
+17. Money as `float64`; note length unconstrained in app layer.
+18. INNER JOIN on items can hide corrupt itemless orders.
+
+---
+
+## 7. Overlaps / confusing concepts (like products’ available vs status vs stock)
+
+| Concept | Intended job | Actual pain |
+|---------|--------------|-------------|
+| `paid` | Payment flag | Orthogonal to status; unpaid `delivered` / paid `pending` possible |
+| `cancelled` vs `expired` vs `deleted` | Manual cancel / timeout / soft-hide | Three “gone” states with **three different stock behaviors** |
+| `pending` reservation | Hold inventory until pay/fulfill | Clear on create; unclear on cancel/delete |
+| Client vs admin cancel | Who may cancel; who restores stock | Role checked only for stock restore, not for permission to cancel |
+
+Recommended product-like clarification (discussion only):
+
+- One “release stock” rule: e.g. release on cancel/expire **before** fulfillment; never after `delivered`; never use `deleted` without release or forbid delete while reserved.
+- Gate `/auth/orders*` mutations (and probably list) to admin, or scope client to **own** orders only.
+
+---
+
+## 8. Multi-tenant / security summary
+
+| Concern | Status |
+|---------|--------|
+| Queries scoped by `tenant_id` | OK |
+| Cross-tenant product IDs | Rejected via tenant product fetch |
+| Inactive tenant on public create | Blocked |
+| Role-based order admin | **Missing** |
+| Client access to all tenant orders | **Open** |
+| Public order create rate limit | **Missing** |
+| Subscription canceled vs public orders | **Inconsistent** |
+
+---
+
+## 9. Test coverage (observed)
+
+**Covered well:** create + stock / `track_inventory`, duplicate line merge, list filters/cursor/search, combined PATCH atomicity, admin/superadmin cancel restore, ghost cancel + multi-tenant isolation.
+
+**Gaps:**
+
+| Gap | Why it matters |
+|-----|----------------|
+| Client JWT listing/updating others’ orders | Authz Critical #1 |
+| `delivered → cancelled` stock restore | Critical #2 |
+| `pending → deleted` stock leak | High #4 |
+| Same-day delivery_date | High #6 |
+| Soft-deleted user reorder | Medium #9 |
+| Public create + canceled subscription | High #5 |
+| Transition matrix / delivered immutability | FSM missing |
+
+---
+
+## 10. File map
+
+| Area | Path |
+|------|------|
+| Status / models | `model/orders/order.go`, `order_items.go`, `order_history.go` |
+| HTTP | `internal/handlers/orders.go` |
+| Validators | `internal/handlers/validators/order_validators.go` |
+| Create | `internal/services/orders/create.go` |
+| Status + stock | `internal/services/orders/update_status.go` |
+| Ghost worker | `internal/services/orders/cancel_expired.go` |
+| Routes | `cmd/api/main.go` |
+| Repo | `internal/repository/orders/order.go` |
+| Stock SQL | `internal/repository/products/product.go` |
+| OpenAPI | `docs/openapi.yaml` |
+| Integration tests | `tests/orders_test.go`, `tests/cancel_expired_orders_test.go` |
+
+---
+
+## 11. Locked decisions (product / API)
+
+Agreed with stakeholders before implementation:
+
+| Topic | Decision | Why |
+|--------|----------|-----|
+| Who manages `/auth/orders*` | **Admin + superadmin only** | Customers must not list/mutate tenant orders via auth APIs yet; mirrors product admin gating |
+| Status workflow | **Linear:** `pending → preparing → ready → delivered` (no skips, no backwards) | Kitchen progression becomes real, not cosmetic |
+| Cancel | Only from `pending` \| `preparing` \| `ready`; **forbidden from `delivered`** | After delivery, order is fulfilled; cancel would corrupt inventory if stock were restored |
+| Stock restore | On **cancel (pre-delivery)** and on **`expired`**; **never after `delivered`** | Reservation = hold until abandoned or sold; sale at delivery keeps stock decremented |
+| Soft-delete (`deleted`) | Allowed **only from** `cancelled` \| `expired` \| `delivered`; **never touches stock** | Delete = hide from default admin lists; stock already resolved in prior status |
+| Subscription canceled | **Block** public `POST` create order | Otherwise a tenant could stop paying and keep earning via the storefront |
+| Same-day delivery | **Allow today** (compare calendar dates, not `Before(time.Now())` on midnight) | `YYYY-MM-DD` is a date, not an instant; today is a valid delivery day |
+| Create response | Return **`id_order`**; prefer **201 Created** | FE can deep-link / confirm the new order |
+| History | Keep **best-effort** writes; **fix incomplete fields** (e.g. ghost `delivery_direction`) | Do not fail checkout/status if history insert fails; do make history rows accurate when written |
+| History HTTP API | **Not in this pass** | Repo already has read helpers; endpoint can wait |
+
+### Target status + stock diagram
+
+```text
+pending → preparing → ready → delivered
+   │          │          │
+   └──────────┴──────────┴──→ cancelled   (restore tracked stock)
+   │
+   └──→ expired (ghost worker, pending+unpaid only; restore tracked stock)
+
+cancelled | expired | delivered ──→ deleted   (no stock change; terminal hide)
+
+blocked examples:
+  delivered → cancelled
+  delivered → preparing
+  pending → deleted
+  pending → ready   (no skip)
+```
+
+### Target stock matrix
+
+| Event | Restore tracked stock? |
+|-------|------------------------|
+| Create | Decrement (if `track_inventory`) |
+| Cancel from `pending` / `preparing` / `ready` | **Yes** |
+| Cancel from `delivered` | **N/A — transition forbidden** |
+| `expired` (worker) | **Yes** |
+| `deleted` (only after cancelled / expired / delivered) | **No** |
+| Reach `delivered` | **No** (reservation becomes sale) |
+
+---
+
+## 12. Implementation plan (what we will cover)
+
+Scope = **Critical + High** from the audit, plus history field fixes (elevated to High). Medium/Low items above stay deferred unless they fall out naturally from these changes.
+
+### Work item 1 — Admin-only auth on order management
+
+**What**
+
+- Put `GET /auth/orders`, `GET /auth/orders/{id}`, `PATCH /auth/orders/{id}` behind `RequireAdminRole` (same pattern as `/auth/products*`).
+- Reject client JWTs with **403**.
+
+**Why**
+
+- Critical #1 / #3: any authenticated client can today list all tenant orders and PATCH cancel/delete without restoring stock → inventory DoS and data leak.
+- Product APIs already require admin; orders must match.
+
+### Work item 2 — Linear status FSM + cancel/delete rules
+
+**What**
+
+- Implement real `validateStatusTransition`:
+  - Forward only: `pending → preparing → ready → delivered`
+  - `cancelled` only from `pending` \| `preparing` \| `ready`
+  - `deleted` only from `cancelled` \| `expired` \| `delivered`
+  - From `cancelled` / `expired` / `deleted`: no further status changes
+  - Reject backwards moves and skips
+- Wire unused / correct error sentinels (`ErrInvalidStatusTransition`, delivered/cancel conflicts as needed).
+- Map transition errors to **400** (or existing HTTPError codes).
+
+**Why**
+
+- Critical #2 and High #9: without an FSM, `delivered → cancelled` restores stock after fulfillment, and kitchen status is meaningless.
+- High #4: forbidding `pending → deleted` prevents soft-delete from locking reserved stock forever; delete never needs to touch inventory.
+
+### Work item 3 — Stock release aligned with FSM
+
+**What**
+
+- On admin cancel (only possible pre-delivery after Work item 2): revert tracked stock in the same TX as today.
+- On ghost `expired`: keep always revert tracked stock.
+- On `deleted`: **never** revert (by construction of allowed sources).
+- Remove any path that restores stock after `delivered` (blocked by FSM).
+- Because clients lose PATCH access (Work item 1), “client cancel without restore” ceases to be a production path.
+
+**Why**
+
+- One coherent reservation model: restore only when the order dies **before** delivery; keep decrement when it completes.
+
+### Work item 4 — Block public create when subscription is canceled
+
+**What**
+
+- On `POST /t/{slug}/orders` and legacy `POST /orders`, reject when tenant subscription is not operable (align with `RequireOperableSubscription` semantics used on `/auth`).
+- Clear HTTP error (403/402/409 — pick consistent with existing subscription middleware).
+
+**Why**
+
+- High #5: a canceled tenant could keep taking storefront orders and earning while not paying for the platform.
+
+### Work item 5 — Same-day delivery_date + create response
+
+**What**
+
+- Validate delivery date as **calendar day ≥ today** in the tenant/server local date basis used by the handler (not `parsedMidnight.Before(time.Now())`).
+- Create success: **201** + body including `id_order` (keep message).
+
+**Why**
+
+- High #6 / #8: date-only field was rejecting “today”; FE needs the new order id.
+
+### Work item 6 — History write completeness (best-effort)
+
+**What**
+
+- Keep history inserts best-effort (do not fail create/status/expire solely because history failed).
+- Fix incomplete history payloads, especially ghost expire path (`delivery_direction` and any other omitted NOT NULL / meaningful fields).
+- Ensure cancel/status history snapshots match the order row fields we care about for audit.
+
+**Why**
+
+- Elevated High #10: incomplete history makes support/audit unreliable even if the order itself is correct.
+
+### Work item 7 — Docs for FE + OpenAPI
+
+**What**
+
+- Update `docs/openapi.yaml` for create/get/patch, public routes, status transitions, subscription block, create 201/`id_order`, authz.
+- Add `docs/FRONTEND_ORDERS_API_CHANGES.md` (mirror product FE changelog) describing admin-only auth orders, FSM, stock/delete rules, delivery date, create response, subscription block.
+
+**Why**
+
+- High #7: FE and contract must match the new rules or clients keep calling legacy assumptions.
+
+### Work item 8 — Tests (TDD around the above)
+
+**What**
+
+- Unit/integration for:
+  - Client JWT → 403 on `/auth/orders*`
+  - Linear transitions allowed / skips & backwards rejected
+  - `delivered → cancelled` rejected; no stock inflate
+  - `pending → deleted` rejected
+  - `cancelled|expired|delivered → deleted` allowed; stock unchanged on delete
+  - Cancel from pre-delivery restores tracked stock
+  - Public create blocked when subscription canceled
+  - Same-day delivery accepted
+  - Create returns 201 + `id_order`
+  - Ghost history includes `delivery_direction` (and related fields)
+
+**Why**
+
+- Lock the Critical/High behavior so regressions do not reopen inventory/auth holes.
+
+---
+
+## 13. Implementation order (PRs / steps)
+
+1. **Authz** — `RequireAdminRole` on `/auth/orders*` + tests  
+2. **FSM + stock matrix** — transition validator, cancel/delete rules, stock restore only pre-delivery + expire  
+3. **Subscription gate** on public create  
+4. **Create UX** — date-only today + `id_order` / 201  
+5. **History field fixes** (best-effort)  
+6. **OpenAPI + FE changelog**  
+7. Full regression on orders + cancel-expired integration tests  
+
+---
+
+## 14. Explicitly out of scope (this pass)
+
+- Client-facing order portal (own-order GET/PATCH)
+- New `GET /auth/orders/{id}/history` endpoint
+- Soft-deleted user reorder fix
+- Rate limiting public create
+- Ghost worker immediate run on boot
+- Changing money type away from `float64`
+- Renaming `OrderItems` JSON to snake_case
+- Skipping forward in the kitchen flow (linear only)
+
+---
+
+## 15. Bottom line
+
+**Today:** tenant scoping is real; role gating is not; stock release and status fight each other.
+
+**After this plan:** only admins manage orders; status is a real linear workflow; stock restores only when an order is abandoned before delivery; delete only hides terminal orders and never touches stock; canceled subscriptions cannot take new storefront orders; create is usable for FE (`id_order`, today allowed); history stays best-effort but complete when written.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -52,7 +52,9 @@ tags:
   - name: Catalog
     description: Catálogo de productos (público o multi-tenant por ruta)
   - name: Orders
-    description: Listado de pedidos (autenticado)
+    description: |
+      Pedidos: create público (storefront) y gestión admin (`/auth/orders*`).
+      Admin requiere JWT **admin/superadmin** y suscripción no `canceled`.
 
 paths:
   /products:
@@ -200,9 +202,15 @@ paths:
   /auth/orders:
     get:
       tags: [Orders]
-      summary: Listar pedidos (autenticado)
+      summary: Listar pedidos (admin)
       description: |
-        Requiere **Bearer JWT** y tenant en contexto (middleware). Orden: **`created_on` ascendente**, desempate **`id_order` ascendente** (más antiguos primero).
+        Requiere **Bearer JWT** de **admin o superadmin**, tenant operable en contexto, y suscripción no `canceled`.
+        Orden: **`created_on` ascendente**, desempate **`id_order` ascendente** (más antiguos primero).
+
+        ### Transiciones de estado (PATCH)
+        Lineales: `pending → preparing → ready → delivered`.
+        `cancelled` solo desde `pending|preparing|ready` (restaura stock rastreado).
+        `deleted` solo desde `cancelled|expired|delivered` (no toca stock).
       operationId: listOrders
       security:
         - bearerAuth: []
@@ -239,6 +247,166 @@ paths:
           $ref: "#/components/responses/BadRequestText"
         "401":
           description: Sin token o token inválido
+        "403":
+          description: Rol insuficiente (no admin/superadmin) o suscripción cancelada
+
+  /auth/orders/{id}:
+    get:
+      tags: [Orders]
+      summary: Obtener pedido por ID (admin)
+      description: |
+        Requiere **Bearer JWT** de **admin o superadmin**.
+        Suscripción `canceled` → 403.
+      operationId: getOrderById
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "200":
+          description: Pedido con ítems
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderListItem"
+        "401":
+          description: Sin token o token inválido
+        "403":
+          description: Rol insuficiente o suscripción cancelada
+        "404":
+          description: Pedido no encontrado
+    patch:
+      tags: [Orders]
+      summary: Actualizar estado y/ o pago (admin)
+      description: |
+        Requiere **Bearer JWT** de **admin o superadmin**.
+
+        ### Transiciones de `status` permitidas
+        - Lineales: `pending → preparing → ready → delivered`
+        - Cancelar: `pending|preparing|ready → cancelled` (restaura stock rastreado)
+        - Soft-delete: `cancelled|expired|delivered → deleted` (no toca stock)
+
+        Saltos, retrocesos, `delivered → cancelled` y delete prematuro → **400**.
+        `expired` solo lo escribe el worker de ghost orders.
+      operationId: updateOrder
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateOrderRequest"
+            examples:
+              nextStep:
+                value:
+                  status: preparing
+              cancel:
+                value:
+                  status: cancelled
+                  cancellation_reason: Cliente canceló
+              markPaid:
+                value:
+                  paid: true
+      responses:
+        "200":
+          description: Actualización correcta (mensaje texto o vacío según handler)
+        "400":
+          description: Payload inválido o transición de estado no permitida
+        "401":
+          description: Sin token o token inválido
+        "403":
+          description: Rol insuficiente o suscripción cancelada
+        "404":
+          description: Pedido no encontrado
+
+  /orders:
+    post:
+      security: []
+      tags: [Orders]
+      summary: Crear pedido (legacy / tenant por cabecera)
+      description: |
+        Create de storefront. Resuelve tenant con `X-Tenant-Slug`.
+        Si la suscripción del tenant es `canceled` (u otras condiciones de
+        disponibilidad), el middleware de tenant responde **404**.
+        Éxito: **201** con `id_order`.
+        `delivery_date` en `YYYY-MM-DD`; **hoy permitido** (día calendario local ≥ hoy).
+      operationId: createOrderLegacy
+      parameters:
+        - name: X-Tenant-Slug
+          in: header
+          required: true
+          schema:
+            type: string
+          example: default
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderRequest"
+      responses:
+        "201":
+          description: Pedido creado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateOrderResponse"
+        "400":
+          description: Validación / fecha / tenant ausente
+        "404":
+          description: Tenant no disponible o producto no encontrado
+        "409":
+          description: Producto no comprable o stock insuficiente
+
+  /t/{tenant_slug}/orders:
+    post:
+      security: []
+      tags: [Orders]
+      summary: Crear pedido por tenant (slug en ruta)
+      description: |
+        Mismo contrato que `POST /orders` (legacy). Preferido para multi-tenant.
+      operationId: createOrderByTenantSlug
+      parameters:
+        - name: tenant_slug
+          in: path
+          required: true
+          schema:
+            type: string
+          example: default
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderRequest"
+      responses:
+        "201":
+          description: Pedido creado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateOrderResponse"
+        "400":
+          description: Validación / fecha
+        "404":
+          description: Tenant no disponible o producto no encontrado
+        "409":
+          description: Producto no comprable o stock insuficiente
 
 components:
   securitySchemes:
@@ -444,3 +612,65 @@ components:
         - cancelled
         - expired
         - deleted
+
+    CreateOrderItem:
+      type: object
+      required: [id_product, quantity]
+      properties:
+        id_product:
+          type: integer
+          format: int64
+          minimum: 1
+        quantity:
+          type: integer
+          format: int64
+          minimum: 1
+
+    CreateOrderRequest:
+      type: object
+      required: [name, email, phone, delivery_date, delivery_direction, items]
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        delivery_date:
+          type: string
+          description: Fecha calendario `YYYY-MM-DD`. Hoy permitido; días pasados → 400.
+          example: "2026-07-27"
+        delivery_direction:
+          type: string
+          description: Dirección o enlace de entrega
+        note:
+          type: string
+        items:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CreateOrderItem"
+
+    CreateOrderResponse:
+      type: object
+      required: [message, id_order]
+      properties:
+        message:
+          type: string
+          example: Order created successfully
+        id_order:
+          type: integer
+          format: int64
+          example: 42
+
+    UpdateOrderRequest:
+      type: object
+      description: Al menos uno de `status` o `paid` es obligatorio.
+      properties:
+        status:
+          $ref: "#/components/schemas/OrderStatus"
+        paid:
+          type: boolean
+        cancellation_reason:
+          type: string

--- a/internal/handlers/orders.go
+++ b/internal/handlers/orders.go
@@ -169,14 +169,16 @@ func (h *OrderHandler) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Date Validations
-	deliveryDate, err := time.Parse("2006-01-02", payload.DeliveryDate)
+	// Date Validations (calendar day >= today in local timezone)
+	deliveryDate, err := time.ParseInLocation("2006-01-02", payload.DeliveryDate, time.Local)
 	if err != nil {
 		http.Error(w, "'delivery_date' must be in YYYY-MM-DD format", http.StatusBadRequest)
 		return
 	}
 
-	if deliveryDate.Before(time.Now()) {
+	now := time.Now().In(time.Local)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	if deliveryDate.Before(today) {
 		http.Error(w, "'delivery_date' can't be before present date", http.StatusBadRequest)
 		return
 	}
@@ -191,7 +193,7 @@ func (h *OrderHandler) CreateOrder(w http.ResponseWriter, r *http.Request) {
 		tenantCfgRepo = h.TenantRepo
 	}
 	orderCreator := orderService.NewCreator(h.Repo, h.UserRepo, h.ProductRepo, tenantCfgRepo)
-	err = orderCreator.CreateOrder(ctx, tenantID, payload, deliveryDate)
+	orderID, err := orderCreator.CreateOrder(ctx, tenantID, payload, deliveryDate)
 	if err != nil {
 		switch {
 		case errors.Is(err, appErrors.ErrProductNotFound):
@@ -208,9 +210,10 @@ func (h *OrderHandler) CreateOrder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{
-		"message": "Order created successfully",
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message":  "Order created successfully",
+		"id_order": orderID,
 	})
 }
 

--- a/internal/middleware/subscription.go
+++ b/internal/middleware/subscription.go
@@ -14,7 +14,7 @@ type SubscriptionSnapshotReader interface {
 }
 
 // RequireOperableSubscription rejects requests when the tenant in context has subscription_status canceled.
-// Apply after AuthMiddleware and TenantMiddleware on business /auth routes.
+// Apply after tenant is resolved (Auth+TenantMiddleware on /auth, or TenantFromPathOrHeader on public create-order).
 func RequireOperableSubscription(reader SubscriptionSnapshotReader) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/services/orders/cancel_expired.go
+++ b/internal/services/orders/cancel_expired.go
@@ -163,6 +163,7 @@ func (c *ExpiredOrderCanceller) revertStockAndRecordHistoryTx(ctx context.Contex
 		Status:             oModel.StatusExpired,
 		Price:              order.Price,
 		Note:               order.Note,
+		DeliveryDirection:  order.DeliveryDirection,
 		Paid:               order.Paid,
 		CancellationReason: &reason,
 		ModifiedBy:         systemModifiedByID,

--- a/internal/services/orders/create.go
+++ b/internal/services/orders/create.go
@@ -90,12 +90,12 @@ func mergeOrderItemsByProduct(items []oModel.CreateOrderItemInput) []oModel.Crea
 	return merged
 }
 
-// CreateOrder creates a costumer order
-func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oModel.CreateOrderPayload, deliveryDate time.Time) error {
+// CreateOrder creates a customer order and returns the new order ID.
+func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oModel.CreateOrderPayload, deliveryDate time.Time) (uint64, error) {
 	// Find user or create it if not found (scoped to tenant)
 	user, err := c.GetOrCreateUser(ctx, tenantID, payload)
 	if err != nil {
-		return fmt.Errorf("error getting or creating user: %w", err)
+		return 0, fmt.Errorf("error getting or creating user: %w", err)
 	}
 
 	mergedItems := mergeOrderItemsByProduct(payload.Items)
@@ -108,17 +108,17 @@ func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oMod
 
 	products, err := c.ProductRepo.GetProductsByIDs(ctx, tenantID, productIDs)
 	if err != nil {
-		return fmt.Errorf("error getting products: %w", err)
+		return 0, fmt.Errorf("error getting products: %w", err)
 	}
 
 	if len(products) != len(productIDs) {
-		return errors.ErrProductNotFound
+		return 0, errors.ErrProductNotFound
 	}
 
 	productMap := make(map[uint64]pModel.Product)
 	for _, p := range products {
 		if p.Status != pModel.StatusActive {
-			return errors.ErrProductNotPurchasable
+			return 0, errors.ErrProductNotPurchasable
 		}
 		productMap[p.ID] = p
 	}
@@ -148,7 +148,7 @@ func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oMod
 
 	tx, err := c.OrderRepo.BeginTx(ctx)
 	if err != nil {
-		return fmt.Errorf("error beginning transaction: %w", err)
+		return 0, fmt.Errorf("error beginning transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -157,17 +157,17 @@ func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oMod
 	for _, item := range mergedItems {
 		trackInventory, err := c.ProductRepo.AssertProductActiveTx(ctx, tx, tenantID, item.IdProduct)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		if !trackInventory {
 			continue
 		}
 		rows, err := c.ProductRepo.DecrementProductStockTx(ctx, tx, tenantID, item.IdProduct, item.Quantity)
 		if err != nil {
-			return fmt.Errorf("error reserving stock: %w", err)
+			return 0, fmt.Errorf("error reserving stock: %w", err)
 		}
 		if rows == 0 {
-			return errors.ErrNotEnoughProductStock
+			return 0, errors.ErrNotEnoughProductStock
 		}
 	}
 
@@ -185,7 +185,7 @@ func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oMod
 
 	orderID, err := c.OrderRepo.CreateOrder(ctx, tx, orderRequest)
 	if err != nil {
-		return fmt.Errorf("error creating order: %w", err)
+		return 0, fmt.Errorf("error creating order: %w", err)
 	}
 
 	orderItems := make([]oModel.OrderItemRequest, len(mergedItems))
@@ -200,7 +200,7 @@ func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oMod
 		}
 	}
 	if err := c.OrderRepo.CreateOrderItems(ctx, tx, tenantID, orderItems); err != nil {
-		return fmt.Errorf("error creating order items: %w", err)
+		return 0, fmt.Errorf("error creating order items: %w", err)
 	}
 
 	idUser := user.ID
@@ -226,9 +226,9 @@ func (c *Creator) CreateOrder(ctx context.Context, tenantID uint64, payload oMod
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("error committing transaction: %w", err)
+		return 0, fmt.Errorf("error committing transaction: %w", err)
 	}
-	return nil
+	return orderID, nil
 }
 
 func (c *Creator) GetOrCreateUser(ctx context.Context, tenantID uint64, payload oModel.CreateOrderPayload) (*uModel.User, error) {

--- a/internal/services/orders/create_test.go
+++ b/internal/services/orders/create_test.go
@@ -248,7 +248,7 @@ func TestCreateOrder_UpdatesProductStock(t *testing.T) {
 	}
 
 	deliveryDate, _ := time.Parse("2006-01-02", payload.DeliveryDate)
-	err = service.CreateOrder(ctx, 1, payload, deliveryDate)
+	_, err = service.CreateOrder(ctx, 1, payload, deliveryDate)
 
 	assert.NoError(t, err)
 	assert.True(t, mockOrderRepo.OrderCreated)
@@ -293,7 +293,7 @@ func TestCreateOrder_MergesDuplicateProductLines(t *testing.T) {
 		DeliveryDate: "2024-12-25",
 	}
 	deliveryDate, _ := time.Parse("2006-01-02", payload.DeliveryDate)
-	err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
+	_, err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
 
 	require.NoError(t, err)
 	assert.Equal(t, []uint64{1}, mockProductRepo.LastIDs)
@@ -339,7 +339,7 @@ func TestCreateOrder_SkipsStockDecrementWhenNotTrackingInventory(t *testing.T) {
 		DeliveryDate: "2024-12-25",
 	}
 	deliveryDate, _ := time.Parse("2006-01-02", payload.DeliveryDate)
-	err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
+	_, err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
 
 	require.NoError(t, err)
 	assert.Equal(t, 0, mockProductRepo.DecrementCalls)
@@ -373,7 +373,7 @@ func TestCreateOrder_RejectsInactiveProduct(t *testing.T) {
 		DeliveryDate: "2024-12-25",
 	}
 	deliveryDate, _ := time.Parse("2006-01-02", payload.DeliveryDate)
-	err := service.CreateOrder(context.Background(), 1, payload, deliveryDate)
+	_, err := service.CreateOrder(context.Background(), 1, payload, deliveryDate)
 
 	assert.ErrorIs(t, err, internalErrors.ErrProductNotPurchasable)
 	assert.False(t, mockOrderRepo.OrderCreated)
@@ -415,7 +415,7 @@ func TestCreateOrder_RejectsWhenProductDeactivatedInsideTx(t *testing.T) {
 		DeliveryDate: "2024-12-25",
 	}
 	deliveryDate, _ := time.Parse("2006-01-02", payload.DeliveryDate)
-	err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
+	_, err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
 
 	assert.ErrorIs(t, err, internalErrors.ErrProductNotPurchasable)
 	assert.False(t, mockOrderRepo.OrderCreated)
@@ -462,7 +462,7 @@ func TestCreateOrder_UsesLockedTrackInventoryWhenEnabledMidCreate(t *testing.T) 
 		DeliveryDate: "2024-12-25",
 	}
 	deliveryDate, _ := time.Parse("2006-01-02", payload.DeliveryDate)
-	err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
+	_, err = service.CreateOrder(context.Background(), 1, payload, deliveryDate)
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, mockProductRepo.DecrementCalls, "must decrement using locked track_inventory, not pre-tx snapshot")
@@ -506,7 +506,7 @@ func TestCreateOrder_RejectsOrderWhenInsufficientStock(t *testing.T) {
 	}
 
 	deliveryDate, _ := time.Parse("2006-01-02", payload.DeliveryDate)
-	err = service.CreateOrder(ctx, 1, payload, deliveryDate)
+	_, err = service.CreateOrder(ctx, 1, payload, deliveryDate)
 
 	assert.ErrorIs(t, err, internalErrors.ErrNotEnoughProductStock)
 	assert.False(t, mockOrderRepo.OrderCreated)
@@ -552,7 +552,7 @@ func TestCreateOrder_SecondOrderFailsAfterStockDepletion(t *testing.T) {
 		DeliveryDate: "2024-12-25",
 	}
 	deliveryDate, _ := time.Parse("2006-01-02", firstPayload.DeliveryDate)
-	err = service.CreateOrder(ctx, 1, firstPayload, deliveryDate)
+	_, err = service.CreateOrder(ctx, 1, firstPayload, deliveryDate)
 	assert.NoError(t, err)
 	assert.True(t, mockOrderRepo.OrderCreated)
 	assert.Equal(t, uint64(0), mockProductRepo.StockUpdates[1])
@@ -574,7 +574,7 @@ func TestCreateOrder_SecondOrderFailsAfterStockDepletion(t *testing.T) {
 		DeliveryDate: "2024-12-26",
 	}
 	deliveryDate2, _ := time.Parse("2006-01-02", secondPayload.DeliveryDate)
-	err2 := service.CreateOrder(ctx, 1, secondPayload, deliveryDate2)
+	_, err2 := service.CreateOrder(ctx, 1, secondPayload, deliveryDate2)
 	assert.ErrorIs(t, err2, internalErrors.ErrNotEnoughProductStock)
 	assert.False(t, mockOrderRepo.OrderCreated)
 	assert.False(t, mockOrderRepo.HistoryCreated)

--- a/internal/services/orders/status_transition_test.go
+++ b/internal/services/orders/status_transition_test.go
@@ -1,0 +1,57 @@
+package orders
+
+import (
+	"testing"
+
+	appErrors "github.com/radamesvaz/bakery-app/internal/errors"
+	oModel "github.com/radamesvaz/bakery-app/model/orders"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateStatusTransition_LinearForward(t *testing.T) {
+	s := &StatusUpdaterWithStock{}
+
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusPending, oModel.StatusPreparing))
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusPreparing, oModel.StatusReady))
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusReady, oModel.StatusDelivered))
+}
+
+func TestValidateStatusTransition_RejectsSkipsAndBackwards(t *testing.T) {
+	s := &StatusUpdaterWithStock{}
+
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusPending, oModel.StatusReady), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusPending, oModel.StatusDelivered), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusPreparing, oModel.StatusDelivered), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusReady, oModel.StatusPreparing), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusDelivered, oModel.StatusPreparing), appErrors.ErrInvalidStatusTransition)
+}
+
+func TestValidateStatusTransition_CancelOnlyBeforeDelivered(t *testing.T) {
+	s := &StatusUpdaterWithStock{}
+
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusPending, oModel.StatusCancelled))
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusPreparing, oModel.StatusCancelled))
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusReady, oModel.StatusCancelled))
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusDelivered, oModel.StatusCancelled), appErrors.ErrOrderAlreadyDelivered)
+}
+
+func TestValidateStatusTransition_DeleteOnlyFromTerminal(t *testing.T) {
+	s := &StatusUpdaterWithStock{}
+
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusPending, oModel.StatusDeleted), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusPreparing, oModel.StatusDeleted), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusReady, oModel.StatusDeleted), appErrors.ErrInvalidStatusTransition)
+
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusCancelled, oModel.StatusDeleted))
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusExpired, oModel.StatusDeleted))
+	assert.NoError(t, s.validateStatusTransition(oModel.StatusDelivered, oModel.StatusDeleted))
+}
+
+func TestValidateStatusTransition_TerminalLocks(t *testing.T) {
+	s := &StatusUpdaterWithStock{}
+
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusCancelled, oModel.StatusCancelled), appErrors.ErrOrderAlreadyCancelled)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusCancelled, oModel.StatusPreparing), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusExpired, oModel.StatusPreparing), appErrors.ErrInvalidStatusTransition)
+	assert.ErrorIs(t, s.validateStatusTransition(oModel.StatusDeleted, oModel.StatusPreparing), appErrors.ErrInvalidStatusTransition)
+}

--- a/internal/services/orders/update_status.go
+++ b/internal/services/orders/update_status.go
@@ -46,19 +46,62 @@ func (s *StatusUpdaterWithStock) validateStatusTransition(currentStatus, newStat
 		if newStatus == oModel.StatusCancelled {
 			return errors.ErrOrderAlreadyCancelled
 		}
+		if newStatus == oModel.StatusDeleted {
+			return nil
+		}
 		return errors.ErrInvalidStatusTransition
 	}
 	if currentStatus == oModel.StatusExpired {
+		if newStatus == oModel.StatusDeleted {
+			return nil
+		}
 		return errors.ErrInvalidStatusTransition
 	}
-	return nil
+	if currentStatus == oModel.StatusDeleted {
+		return errors.ErrInvalidStatusTransition
+	}
+	if currentStatus == oModel.StatusDelivered {
+		if newStatus == oModel.StatusDeleted {
+			return nil
+		}
+		if newStatus == oModel.StatusCancelled {
+			return errors.ErrOrderAlreadyDelivered
+		}
+		return errors.ErrInvalidStatusTransition
+	}
+
+	// From pending | preparing | ready
+	switch newStatus {
+	case oModel.StatusCancelled:
+		return nil
+	case oModel.StatusDeleted:
+		// Soft-delete only after cancelled | expired | delivered (never touches stock).
+		return errors.ErrInvalidStatusTransition
+	case oModel.StatusPreparing:
+		if currentStatus == oModel.StatusPending {
+			return nil
+		}
+	case oModel.StatusReady:
+		if currentStatus == oModel.StatusPreparing {
+			return nil
+		}
+	case oModel.StatusDelivered:
+		if currentStatus == oModel.StatusReady {
+			return nil
+		}
+	}
+	return errors.ErrInvalidStatusTransition
 }
 
-// UpdateOrderStatusWithStockReversion updates order status and reverts stock if admin cancels order.
-// cancellationReason is optional; only used when newStatus is cancelled (e.g. user-provided reason or nil).
+// UpdateOrderStatusWithStockReversion updates order status and reverts stock when the order is cancelled.
+// cancellationReason is optional; only used when newStatus is cancelled.
 // paidOverride, when non-nil, updates paid in the same transaction as status and is used for history
 // (combined status+paid PATCH stays atomic).
+// isAdmin is retained for call-site compatibility; HTTP auth already restricts PATCH to admins.
+// Cancel always restores tracked stock (FSM only allows cancel before delivered).
 func (s *StatusUpdaterWithStock) UpdateOrderStatusWithStockReversion(ctx context.Context, tenantID, orderID uint64, newStatus oModel.OrderStatus, userID uint64, isAdmin bool, cancellationReason *string, paidOverride *bool) error {
+	_ = isAdmin
+
 	// Get the current order
 	order, err := s.OrderRepo.GetOrderByID(ctx, tenantID, orderID)
 	if err != nil {
@@ -80,7 +123,8 @@ func (s *StatusUpdaterWithStock) UpdateOrderStatusWithStockReversion(ctx context
 		paidForHistory = *paidOverride
 	}
 
-	needsStockRevert := isAdmin && newStatus == oModel.StatusCancelled
+	// Cancel is only allowed pre-delivery (FSM). Always restore tracked stock on cancel.
+	needsStockRevert := newStatus == oModel.StatusCancelled
 	needsPaidUpdate := paidOverride != nil
 
 	// Use a transaction when status must stay atomic with stock reversion and/or paid.

--- a/internal/services/orders/update_status_with_stock_test.go
+++ b/internal/services/orders/update_status_with_stock_test.go
@@ -102,6 +102,9 @@ func TestValidateStatusTransition_RejectsFromCancelledOrExpired(t *testing.T) {
 
 	err = s.validateStatusTransition(oModel.StatusPending, oModel.StatusPreparing)
 	assert.NoError(t, err)
+
+	err = s.validateStatusTransition(oModel.StatusCancelled, oModel.StatusDeleted)
+	assert.NoError(t, err)
 }
 
 func TestUpdateOrderStatus_AdminCancelsOrder_RevertsStock(t *testing.T) {
@@ -153,8 +156,14 @@ func TestUpdateOrderStatus_AdminCancelsOrder_RevertsStock(t *testing.T) {
 	require.NoError(t, sqlMock.ExpectationsWereMet())
 }
 
-func TestUpdateOrderStatus_ClientCancelsOrder_NoStockRevert(t *testing.T) {
-	mockOrderRepo := new(MockOrderStatusRepositoryWithStock)
+func TestUpdateOrderStatus_Cancel_AlwaysRevertsStock(t *testing.T) {
+	db, sqlMock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	sqlMock.ExpectBegin()
+	sqlMock.ExpectCommit()
+
+	mockOrderRepo := &MockOrderStatusRepositoryWithStock{DB: db}
 	mockProductRepo := new(MockProductRepositoryWithStock)
 
 	order := oModel.OrderResponse{
@@ -164,10 +173,99 @@ func TestUpdateOrderStatus_ClientCancelsOrder_NoStockRevert(t *testing.T) {
 		Status:   oModel.StatusPending,
 		Price:    15.0,
 	}
+	orderItems := []oModel.OrderItems{
+		{ID: 1, IdOrder: 1, IdProduct: 1, Name: "Product 1", Quantity: 3},
+	}
 
 	const tenantID = uint64(1)
 	mockOrderRepo.On("GetOrderByID", mock.Anything, tenantID, uint64(1)).Return(order, nil)
-	mockOrderRepo.On("UpdateOrderStatus", mock.Anything, tenantID, uint64(1), oModel.StatusCancelled, (*string)(nil)).Return(nil)
+	mockOrderRepo.On("UpdateOrderStatusTx", mock.Anything, mock.Anything, tenantID, uint64(1), oModel.StatusCancelled, (*string)(nil)).Return(nil)
+	mockOrderRepo.On("CreateOrderHistoryTx", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockOrderRepo.On("GetOrderItemsByOrderIDTx", mock.Anything, mock.Anything, tenantID, uint64(1)).Return(orderItems, nil)
+	mockProductRepo.On("RevertProductStockTx", mock.Anything, mock.Anything, tenantID, uint64(1), uint64(3)).Return(nil)
+
+	statusUpdater := &StatusUpdaterWithStock{
+		OrderRepo:   mockOrderRepo,
+		ProductRepo: mockProductRepo,
+	}
+
+	// isAdmin=false retained for API compat; cancel still restores stock (HTTP is admin-only).
+	err = statusUpdater.UpdateOrderStatusWithStockReversion(context.Background(), tenantID, 1, oModel.StatusCancelled, 2, false, nil, nil)
+
+	assert.NoError(t, err)
+	mockOrderRepo.AssertExpectations(t)
+	mockProductRepo.AssertExpectations(t)
+	require.NoError(t, sqlMock.ExpectationsWereMet())
+}
+
+func TestUpdateOrderStatus_DeliveredToCancelled_Rejected(t *testing.T) {
+	mockOrderRepo := new(MockOrderStatusRepositoryWithStock)
+	mockProductRepo := new(MockProductRepositoryWithStock)
+
+	order := oModel.OrderResponse{
+		ID:       1,
+		TenantID: 1,
+		IdUser:   1,
+		Status:   oModel.StatusDelivered,
+		Price:    15.0,
+	}
+
+	const tenantID = uint64(1)
+	mockOrderRepo.On("GetOrderByID", mock.Anything, tenantID, uint64(1)).Return(order, nil)
+
+	statusUpdater := &StatusUpdaterWithStock{
+		OrderRepo:   mockOrderRepo,
+		ProductRepo: mockProductRepo,
+	}
+
+	err := statusUpdater.UpdateOrderStatusWithStockReversion(context.Background(), tenantID, 1, oModel.StatusCancelled, 1, true, nil, nil)
+
+	assert.ErrorIs(t, err, appErrors.ErrOrderAlreadyDelivered)
+	mockProductRepo.AssertNotCalled(t, "RevertProductStockTx")
+	mockProductRepo.AssertNotCalled(t, "RevertProductStock")
+}
+
+func TestUpdateOrderStatus_PendingToDeleted_Rejected(t *testing.T) {
+	mockOrderRepo := new(MockOrderStatusRepositoryWithStock)
+	mockProductRepo := new(MockProductRepositoryWithStock)
+
+	order := oModel.OrderResponse{
+		ID:       1,
+		TenantID: 1,
+		IdUser:   1,
+		Status:   oModel.StatusPending,
+		Price:    15.0,
+	}
+
+	const tenantID = uint64(1)
+	mockOrderRepo.On("GetOrderByID", mock.Anything, tenantID, uint64(1)).Return(order, nil)
+
+	statusUpdater := &StatusUpdaterWithStock{
+		OrderRepo:   mockOrderRepo,
+		ProductRepo: mockProductRepo,
+	}
+
+	err := statusUpdater.UpdateOrderStatusWithStockReversion(context.Background(), tenantID, 1, oModel.StatusDeleted, 1, true, nil, nil)
+
+	assert.ErrorIs(t, err, appErrors.ErrInvalidStatusTransition)
+	mockProductRepo.AssertNotCalled(t, "RevertProductStockTx")
+}
+
+func TestUpdateOrderStatus_CancelledToDeleted_NoStockRevert(t *testing.T) {
+	mockOrderRepo := new(MockOrderStatusRepositoryWithStock)
+	mockProductRepo := new(MockProductRepositoryWithStock)
+
+	order := oModel.OrderResponse{
+		ID:       1,
+		TenantID: 1,
+		IdUser:   1,
+		Status:   oModel.StatusCancelled,
+		Price:    15.0,
+	}
+
+	const tenantID = uint64(1)
+	mockOrderRepo.On("GetOrderByID", mock.Anything, tenantID, uint64(1)).Return(order, nil)
+	mockOrderRepo.On("UpdateOrderStatus", mock.Anything, tenantID, uint64(1), oModel.StatusDeleted, (*string)(nil)).Return(nil)
 	mockOrderRepo.On("CreateOrderHistory", mock.Anything, mock.Anything).Return(nil)
 
 	statusUpdater := &StatusUpdaterWithStock{
@@ -175,10 +273,9 @@ func TestUpdateOrderStatus_ClientCancelsOrder_NoStockRevert(t *testing.T) {
 		ProductRepo: mockProductRepo,
 	}
 
-	err := statusUpdater.UpdateOrderStatusWithStockReversion(context.Background(), tenantID, 1, oModel.StatusCancelled, 2, false, nil, nil)
+	err := statusUpdater.UpdateOrderStatusWithStockReversion(context.Background(), tenantID, 1, oModel.StatusDeleted, 1, true, nil, nil)
 
 	assert.NoError(t, err)
-	mockOrderRepo.AssertExpectations(t)
 	mockProductRepo.AssertNotCalled(t, "RevertProductStockTx")
 	mockProductRepo.AssertNotCalled(t, "RevertProductStock")
 }

--- a/tests/orders_test.go
+++ b/tests/orders_test.go
@@ -50,6 +50,7 @@ func TestGetAllOrders(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
@@ -182,6 +183,7 @@ func TestGetAllOrdersFilteredByIDUser(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
 	tenantID := uint64(1)
@@ -246,6 +248,7 @@ func TestGetOrderByID(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders/{id}", orderHandler.GetOrderByID).Methods("GET")
 
@@ -346,12 +349,11 @@ func TestCreateOrder(t *testing.T) {
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
-	expected := `{
-			"message": "Order created successfully"
-		}`
-
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.JSONEq(t, expected, rr.Body.String())
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	var createResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &createResp))
+	assert.Equal(t, "Order created successfully", createResp["message"])
+	assert.NotZero(t, createResp["id_order"])
 }
 
 func TestLegacyCreateOrder_WithoutTenantMiddlewareReturns400(t *testing.T) {
@@ -422,8 +424,11 @@ func TestLegacyCreateOrder_WithXTenantSlugHeader(t *testing.T) {
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.JSONEq(t, `{"message": "Order created successfully"}`, rr.Body.String())
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	var createResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &createResp))
+	assert.Equal(t, "Order created successfully", createResp["message"])
+	assert.NotZero(t, createResp["id_order"])
 }
 
 func TestCreateOrder_MissingDeliveryDirection(t *testing.T) {
@@ -545,7 +550,10 @@ func TestCreateOrder_WithOrderHistory(t *testing.T) {
 	router.ServeHTTP(rr, req)
 
 	// Verify the order was created successfully
-	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	var createResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &createResp))
+	assert.NotZero(t, createResp["id_order"])
 
 	// Get the latest order ID by querying the database
 	// Since we don't know the exact ID, we'll get the max ID from orders table
@@ -553,6 +561,7 @@ func TestCreateOrder_WithOrderHistory(t *testing.T) {
 	var latestOrderID uint64
 	err := db.QueryRowContext(ctx, "SELECT MAX(id_order) FROM orders").Scan(&latestOrderID)
 	assert.NoError(t, err, "Should be able to get latest order ID")
+	assert.Equal(t, float64(latestOrderID), createResp["id_order"])
 
 	// Verify that order history was created
 	const tenantID = uint64(1)
@@ -596,6 +605,7 @@ func TestUpdateOrderStatus_Success(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
 
@@ -629,13 +639,13 @@ func TestUpdateOrderStatus_Success(t *testing.T) {
 	createRR := httptest.NewRecorder()
 	router.ServeHTTP(createRR, createReq)
 
-	assert.Equal(t, http.StatusOK, createRR.Code, "Order should be created successfully")
+	assert.Equal(t, http.StatusCreated, createRR.Code, "Order should be created successfully")
+	var createResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(createRR.Body.Bytes(), &createResp))
+	orderID := uint64(createResp["id_order"].(float64))
+	assert.NotZero(t, orderID)
 
-	// Get the created order ID
 	ctx := context.Background()
-	var orderID uint64
-	err := db.QueryRowContext(ctx, "SELECT MAX(id_order) FROM orders").Scan(&orderID)
-	assert.NoError(t, err, "Should be able to get created order ID")
 
 	// Generate JWT for authentication
 	tenantID := uint64(1)
@@ -712,6 +722,7 @@ func TestUpdateOrderStatus_OrderNotFound(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
 
@@ -755,6 +766,7 @@ func TestUpdateOrder_StatusAndPaid(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
 
@@ -831,6 +843,7 @@ func TestUpdateOrder_StatusFailure_DoesNotUpdatePaid(t *testing.T) {
 	authService := auth.New(secret, 60)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
 
 	tenantID := uint64(1)
@@ -881,6 +894,7 @@ func TestUpdateOrder_InvalidPayload(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
 
@@ -944,6 +958,7 @@ func TestGetAllOrdersWithIgnoreStatus(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
@@ -1008,6 +1023,7 @@ func TestGetAllOrdersWithStatusFilter(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
@@ -1085,6 +1101,7 @@ func TestGetAllOrdersWithCombinedFilters(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
@@ -1131,6 +1148,7 @@ func TestGetAllOrders_WithSearchQuery(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
 	tenantID := uint64(1)
@@ -1174,6 +1192,7 @@ func TestGetAllOrders_OrderByCreatedOnAndCursor(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
 	tenantID := uint64(1)
@@ -1233,6 +1252,7 @@ func TestGetAllOrders_SearchWithCombinedFiltersAndCursor(t *testing.T) {
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
 	tenantID := uint64(1)
@@ -1324,6 +1344,7 @@ func TestGetAllOrders_SearchAndUserFilter_MultiPageCursorContinuity(t *testing.T
 	var authService auth.Service = auth.New(secret, exp)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
 
 	tenantID := uint64(1)
@@ -1394,6 +1415,7 @@ func TestUpdateOrder_SuperAdminCancel_RestoresStock(t *testing.T) {
 	authService := auth.New("testingsecret", 60)
 	authRouter.Use(middleware.AuthMiddleware(authService))
 	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
 	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
 
 	tenantID := uint64(1)
@@ -1417,4 +1439,243 @@ func TestUpdateOrder_SuperAdminCancel_RestoresStock(t *testing.T) {
 	err = db.QueryRow(`SELECT stock FROM products WHERE tenant_id = $1 AND id_product = 2`, tenantID).Scan(&stockAfter)
 	require.NoError(t, err)
 	assert.Equal(t, stockBefore+2, stockAfter, "superadmin cancel must restore inventory like admin")
+}
+
+func TestAuthOrders_ClientRoleForbidden(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	orderHandler := handlers.OrderHandler{Repo: &ordersRepository.OrderRepository{DB: db}}
+	router := mux.NewRouter()
+	authRouter := router.PathPrefix("/auth").Subrouter()
+	authService := auth.New("testingsecret", 60)
+	authRouter.Use(middleware.AuthMiddleware(authService))
+	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
+	authRouter.HandleFunc("/orders", orderHandler.GetAllOrders).Methods("GET")
+	authRouter.HandleFunc("/orders/{id}", orderHandler.GetOrderByID).Methods("GET")
+	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
+
+	tenantID := uint64(1)
+	clientJWT, err := authService.GenerateJWT(2, uModel.UserRoleClient, "client@example.com", &tenantID)
+	require.NoError(t, err)
+
+	cases := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodGet, "/auth/orders", ""},
+		{http.MethodGet, "/auth/orders/1", ""},
+		{http.MethodPatch, "/auth/orders/2", `{"status":"preparing"}`},
+	}
+	for _, tc := range cases {
+		var req *http.Request
+		if tc.body == "" {
+			req = httptest.NewRequest(tc.method, tc.path, nil)
+		} else {
+			req = httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("Authorization", "Bearer "+clientJWT)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusForbidden, rr.Code, "%s %s", tc.method, tc.path)
+	}
+}
+
+func TestCreateOrder_SameDayDeliveryAccepted(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	orderHandler := handlers.OrderHandler{
+		Repo:        &ordersRepository.OrderRepository{DB: db},
+		UserRepo:    userRepo.NewUserRepository(db),
+		ProductRepo: &productRepo.ProductRepository{DB: db},
+	}
+	router := mux.NewRouter()
+	router.HandleFunc("/orders", orderHandler.CreateOrder).Methods("POST")
+
+	today := time.Now().In(time.Local).Format("2006-01-02")
+	payload := fmt.Sprintf(`{
+		"name": "Same Day",
+		"email": "sameday@example.com",
+		"phone": "1234567890",
+		"delivery_date": "%s",
+		"delivery_direction": "https://maps.app.goo.gl/same-day",
+		"items": [{"id_product": 1, "quantity": 1}]
+	}`, today)
+
+	req := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req = withTenantContext(req, 1)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
+	var createResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &createResp))
+	assert.NotZero(t, createResp["id_order"])
+}
+
+func TestCreateOrder_PastDeliveryDateRejected(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	orderHandler := handlers.OrderHandler{
+		Repo:        &ordersRepository.OrderRepository{DB: db},
+		UserRepo:    userRepo.NewUserRepository(db),
+		ProductRepo: &productRepo.ProductRepository{DB: db},
+	}
+	router := mux.NewRouter()
+	router.HandleFunc("/orders", orderHandler.CreateOrder).Methods("POST")
+
+	yesterday := time.Now().In(time.Local).AddDate(0, 0, -1).Format("2006-01-02")
+	payload := fmt.Sprintf(`{
+		"name": "Past Day",
+		"email": "pastday@example.com",
+		"phone": "1234567890",
+		"delivery_date": "%s",
+		"delivery_direction": "https://maps.app.goo.gl/past-day",
+		"items": [{"id_product": 1, "quantity": 1}]
+	}`, yesterday)
+
+	req := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req = withTenantContext(req, 1)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "delivery_date")
+}
+
+func TestCreateOrder_SubscriptionCanceled_Public404(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	_, err := db.Exec(`UPDATE tenants SET subscription_status = 'canceled' WHERE slug = 'default'`)
+	require.NoError(t, err)
+
+	tenantRepo := &tenantRepository.Repository{DB: db}
+	orderHandler := handlers.OrderHandler{
+		Repo:        &ordersRepository.OrderRepository{DB: db},
+		UserRepo:    userRepo.NewUserRepository(db),
+		ProductRepo: &productRepo.ProductRepository{DB: db},
+	}
+
+	router := mux.NewRouter()
+	tPublic := router.PathPrefix("/t/{tenant_slug}").Subrouter()
+	tPublic.Use(middleware.TenantFromPathOrHeader(tenantRepo))
+	tPublicOrders := tPublic.PathPrefix("").Subrouter()
+	tPublicOrders.Use(middleware.RequireOperableSubscription(tenantRepo))
+	tPublicOrders.HandleFunc("/orders", orderHandler.CreateOrder).Methods("POST")
+
+	today := time.Now().In(time.Local).Format("2006-01-02")
+	payload := fmt.Sprintf(`{
+		"name": "Canceled Sub",
+		"email": "canceledsub@example.com",
+		"phone": "1234567890",
+		"delivery_date": "%s",
+		"delivery_direction": "https://maps.app.goo.gl/canceled",
+		"items": [{"id_product": 1, "quantity": 1}]
+	}`, today)
+
+	req := httptest.NewRequest(http.MethodPost, "/t/default/orders", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestUpdateOrder_RejectsInvalidTransitions(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	orderHandler := handlers.OrderHandler{
+		Repo:        &ordersRepository.OrderRepository{DB: db},
+		ProductRepo: &productRepo.ProductRepository{DB: db},
+	}
+	router := mux.NewRouter()
+	authRouter := router.PathPrefix("/auth").Subrouter()
+	authService := auth.New("testingsecret", 60)
+	authRouter.Use(middleware.AuthMiddleware(authService))
+	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
+	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
+
+	tenantID := uint64(1)
+	jwt, err := authService.GenerateJWT(1, uModel.UserRoleAdmin, "admin@example.com", &tenantID)
+	require.NoError(t, err)
+
+	patch := func(orderID uint64, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/auth/orders/%d", orderID), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+jwt)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// Seed: order 2 pending — skip to ready rejected
+	rr := patch(2, `{"status":"ready"}`)
+	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+
+	// Seed: order 1 delivered — cancel rejected
+	rr = patch(1, `{"status":"cancelled"}`)
+	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+
+	// Seed: order 2 pending — delete rejected
+	rr = patch(2, `{"status":"deleted"}`)
+	assert.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+}
+
+func TestUpdateOrder_DeleteFromDelivered_DoesNotTouchStock(t *testing.T) {
+	_, db, terminate, dsn := setupPostgreSQLContainer(t)
+	defer terminate()
+	runMigrations(t, dsn)
+
+	orderHandler := handlers.OrderHandler{
+		Repo:        &ordersRepository.OrderRepository{DB: db},
+		ProductRepo: &productRepo.ProductRepository{DB: db},
+	}
+	router := mux.NewRouter()
+	authRouter := router.PathPrefix("/auth").Subrouter()
+	authService := auth.New("testingsecret", 60)
+	authRouter.Use(middleware.AuthMiddleware(authService))
+	authRouter.Use(middleware.TenantMiddleware(nil))
+	authRouter.Use(middleware.RequireAdminRole())
+	authRouter.HandleFunc("/orders/{id}", orderHandler.UpdateOrder).Methods("PATCH")
+
+	tenantID := uint64(1)
+	jwt, err := authService.GenerateJWT(1, uModel.UserRoleAdmin, "admin@example.com", &tenantID)
+	require.NoError(t, err)
+
+	var stockBefore int
+	err = db.QueryRow(`SELECT stock FROM products WHERE tenant_id = $1 AND id_product = 1`, tenantID).Scan(&stockBefore)
+	require.NoError(t, err)
+
+	// Seed order 1 is delivered
+	req := httptest.NewRequest(http.MethodPatch, "/auth/orders/1", strings.NewReader(`{"status":"deleted"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	var status string
+	err = db.QueryRow(`SELECT status FROM orders WHERE id_order = 1`).Scan(&status)
+	require.NoError(t, err)
+	assert.Equal(t, "deleted", status)
+
+	var stockAfter int
+	err = db.QueryRow(`SELECT stock FROM products WHERE tenant_id = $1 AND id_product = 1`, tenantID).Scan(&stockAfter)
+	require.NoError(t, err)
+	assert.Equal(t, stockBefore, stockAfter, "delete after delivered must not restore stock")
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes authentication, inventory restoration, and public checkout behavior—breaking for client JWTs on `/auth/orders*` and any UI assuming loose status transitions or 200 create without `id_order`.
> 
> **Overview**
> **Orders flow hardening** closes auth/inventory gaps and aligns the public create contract with admin workflows.
> 
> **Access control:** `GET`/`PATCH` `/auth/orders*` now sit behind `RequireAdminRole` (with `/auth/products*`). Client JWTs get **403**. Public checkout stays unauthenticated on `POST /t/{slug}/orders` and legacy `POST /orders`.
> 
> **Status + stock:** Admin PATCH enforces a **linear** kitchen path (`pending → preparing → ready → delivered`), cancel only before delivery, and soft-delete only from `cancelled` / `expired` / `delivered` without touching stock. Pre-delivery **cancel** always restores tracked inventory (not gated on admin flag inside the updater). Invalid transitions (skips, backwards, `delivered → cancelled`, early delete) return **400**.
> 
> **Storefront create:** `RequireOperableSubscription` wraps public create routes so canceled tenants cannot place orders. Success is **201** with `id_order`; `delivery_date` allows **today** via local calendar-day comparison.
> 
> **Docs/tests:** OpenAPI and a frontend changelog document the new rules; integration and unit tests cover FSM, authz, subscription block, and create response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939f1369ba74ef457f0dd109048473d25ffb4313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->