### PR TITLE
adding date sorting for orders search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## API (listados)
 
 - **GET `/products`** y **GET `/t/{tenant_slug}/products`**: la respuesta es un objeto `{ "items", "next_cursor" }` (ya no un array en la raíz). Query opcional **`q`**: búsqueda por nombre **contiene** (insensible a mayúsculas), mínimo 2 caracteres; combinable con `limit` y `cursor`.
-- **GET `/auth/orders`**: mismo envelope `{ "items", "next_cursor" }`. Query opcional **`id_user`**: filtra pedidos de ese usuario (entero `> 0`); combinable con `ignore_status`, `status`, `limit`, `cursor`.
+- **GET `/auth/orders`**: mismo envelope `{ "items", "next_cursor" }`. Orden **más recientes primero** (`created_on DESC`, `id_order DESC`); cursor **v3** (cursores v2 inválidos). Query opcional **`id_user`**: filtra pedidos de ese usuario (entero `> 0`); combinable con `ignore_status`, `status`, `q`, `limit`, `cursor`.
 
 Los cursores de productos y de órdenes **no** son intercambiables (formatos distintos).
 

--- a/docs/FRONTEND_ORDERS_API_CHANGES.md
+++ b/docs/FRONTEND_ORDERS_API_CHANGES.md
@@ -9,6 +9,7 @@ Backend changes the frontend must adopt for checkout and admin order management.
 | Area | What changed |
 |------|----------------|
 | `/auth/orders*` | **Admin / superadmin only** (client JWT → **403**) |
+| `GET /auth/orders` sort | **Newest first** (`created_on DESC`); cursor **v3** (v2 invalid) |
 | Status workflow | **Linear only:** `pending → preparing → ready → delivered` |
 | Cancel | Only from `pending` / `preparing` / `ready` — **not** from `delivered` |
 | Soft-delete | Only from `cancelled` / `expired` / `delivered` — never touches stock |
@@ -125,6 +126,15 @@ Default `GET /auth/orders` still hides `deleted` unless `ignore_status=true` or 
 
 ---
 
+## 4b. List sort — newest first
+
+`GET /auth/orders` returns orders by **`created_on` DESC** (tie-break `id_order` DESC).
+
+- First page = most recent orders (also when using `q` / `status` / `id_user`).
+- Order cursor is **version 3**. Old v2 cursors are rejected (**400** `Invalid cursor`) — drop any cached `next_cursor` and refetch from page 1.
+
+---
+
 ## 5. Migration checklist (FE)
 
 - [ ] Ensure admin order screens use **admin JWT** (not client)
@@ -136,6 +146,7 @@ Default `GET /auth/orders` still hides `deleted` unless `ignore_status=true` or 
 - [ ] Allow selecting **today** as delivery date
 - [ ] Handle **404** on public create when subscription canceled (“store unavailable”)
 - [ ] Sold-out / 409 handling unchanged from product hardening
+- [ ] Admin order list: assume **newest first**; discard stale order cursors (v2 → v3)
 
 ---
 

--- a/docs/FRONTEND_TENANT_WHATSAPP_API_CHANGES.md
+++ b/docs/FRONTEND_TENANT_WHATSAPP_API_CHANGES.md
@@ -1,0 +1,185 @@
+# Frontend changelog — Tenant WhatsApp phone
+
+Backend changes the frontend must adopt so checkout invoice deep links and admin settings use the bakery’s WhatsApp number from the API (not a hardcoded / env-only value on the client).
+
+Design context: [`TENANT_WHATSAPP_PHONE.md`](./TENANT_WHATSAPP_PHONE.md).
+
+---
+
+## Summary
+
+| Area | What changed |
+|------|----------------|
+| Store WhatsApp contact | **New** tenant field `whatsapp_phone` (not the admin user’s `phone`) |
+| Public branding | `GET /t/{slug}/branding` → `branding.whatsapp_phone` |
+| Admin update | `PATCH /auth/branding/whatsapp` (admin JWT) |
+| Tenant register | Optional `whatsapp_phone` on `POST /public/tenant-register` |
+| Backend WhatsApp send | **None** — FE still opens WhatsApp / `wa.me` |
+
+---
+
+## 1. Mental model (do not mix these)
+
+| Field | Where it lives | Use for |
+|-------|----------------|---------|
+| `phone` on register / user | Admin `users.phone` | Account / contact for the person who signed up |
+| `whatsapp_phone` | `tenants.whatsapp_phone` | Storefront invoice destination (“message the bakery”) |
+
+Same person often owns both at signup. The API does **not** copy admin `phone` into `whatsapp_phone`. The registration UI may prefill WhatsApp from the admin phone for convenience, but must send `whatsapp_phone` explicitly if it should be stored.
+
+---
+
+## 2. Public branding (storefront)
+
+### Endpoint
+
+`GET /t/{tenant_slug}/branding`  
+(or legacy path + `X-Tenant-Slug` if you still use it)
+
+### Response shape (relevant part)
+
+```json
+{
+  "tenant_id": 1,
+  "tenant_slug": "acme-bakery",
+  "branding": {
+    "tenant_name": "Acme Bakery",
+    "logo_url": "https://...",
+    "primary_color": "#111827",
+    "secondary_color": "#374151",
+    "accent_color": "#F59E0B",
+    "whatsapp_phone": "+584121234567"
+  }
+}
+```
+
+| Value | Meaning |
+|-------|---------|
+| Non-empty string | Use for checkout → WhatsApp invoice link |
+| `""` | Unset — do not invent a number; warn / block “send invoice” |
+
+Types / store: add `whatsapp_phone: string` on the branding object (default `""` if missing for older caches).
+
+### Checkout
+
+1. Load branding (you likely already do for name/colors/logo).
+2. After a successful order create (`201` + `id_order`), build the WhatsApp link from `branding.whatsapp_phone`.
+3. If `whatsapp_phone` is empty, show a clear message (“Bakery WhatsApp not configured”) instead of opening WhatsApp with a wrong/hardcoded number.
+
+Suggested link shape (FE responsibility):
+
+```text
+https://wa.me/<digitsOnly>?text=<urlencoded invoice message>
+```
+
+Strip non-digits for `wa.me` if your current helper already does that; keep displaying the stored string as-is in admin UI.
+
+---
+
+## 3. Update WhatsApp (admin settings / branding)
+
+### Endpoint
+
+`PATCH /auth/branding/whatsapp`
+
+- Auth: **admin JWT** (same tenant context as other `/auth/branding/*` routes)
+- Client role → **403 Forbidden**
+- Superadmin is not treated as admin on this route → **403** (use a tenant admin session)
+
+### Request
+
+```json
+{ "whatsapp_phone": "+584121234567" }
+```
+
+| Case | Behavior |
+|------|----------|
+| `"whatsapp_phone": "+58..."` | Set / replace |
+| `"whatsapp_phone": ""` | Clear (stored as unset; branding returns `""`) |
+| Key omitted | **400** `whatsapp_phone is required` |
+| Longer than **20** characters (after trim) | **400** |
+| Invalid JSON | **400** |
+
+### Success (200)
+
+```json
+{
+  "message": "WhatsApp phone updated successfully",
+  "tenant_id": 1,
+  "tenant_slug": "acme-bakery",
+  "whatsapp_phone": "+584121234567"
+}
+```
+
+After a successful PATCH, update local branding state (or refetch `GET .../branding`) so the storefront preview matches.
+
+---
+
+## 4. Tenant registration
+
+### Endpoint
+
+`POST /public/tenant-register`
+
+### Body (new optional field)
+
+```json
+{
+  "tenant_name": "Acme Bakery",
+  "admin_name": "Owner Admin",
+  "email": "owner@acme.com",
+  "phone": "555-0101",
+  "whatsapp_phone": "+584121234567",
+  "password": "StrongPass123!",
+  "one_time_code": "ABCD1234-EFGH5678"
+}
+```
+
+| Field | Required | Stored as |
+|-------|----------|-----------|
+| `phone` | optional (unchanged) | Admin user phone |
+| `whatsapp_phone` | optional | Tenant store WhatsApp |
+
+- Omitted or blank `whatsapp_phone` → tenant WhatsApp left unset (`""` on branding until configured).
+- Max length **20** after trim → **400** if exceeded.
+- Register response does **not** need to return `whatsapp_phone`; confirm via branding after login if needed.
+
+### UX suggestion
+
+- Label admin phone vs store WhatsApp clearly.
+- Prefill WhatsApp from admin phone in the form only; still submit `whatsapp_phone` as its own field.
+- If left empty at signup, prompt in admin branding/settings before the bakery goes live.
+
+---
+
+## 5. Existing tenants
+
+Tenants created before this change have `whatsapp_phone` empty until an admin sets it.
+
+Do **not** fall back to:
+
+- Hardcoded FE env WhatsApp
+- Admin user phone from login/profile (unless you explicitly choose that as a temporary UX fallback — backend will not)
+
+Preferred: empty state + CTA to “Set bakery WhatsApp” in branding settings.
+
+---
+
+## 6. Migration checklist (FE)
+
+- [ ] Extend branding type / store with `whatsapp_phone: string`
+- [ ] Checkout invoice link reads `branding.whatsapp_phone` only
+- [ ] Handle empty WhatsApp (warn / block), no silent hardcoded fallback
+- [ ] Registration: optional store WhatsApp field; map to `whatsapp_phone` (not `phone`)
+- [ ] Admin branding/settings: display + edit via `PATCH /auth/branding/whatsapp`
+- [ ] Allow clear (send `""`) if product supports “remove number”
+- [ ] Always send the `whatsapp_phone` key on PATCH (never omit)
+- [ ] Enforce max 20 chars in the form to match API
+
+---
+
+## 7. Out of scope (no FE work expected from backend)
+
+- Backend sending WhatsApp / invoice templates
+- Dedicated public “tenant details” endpoint (use branding)
+- Bootstrap / invitation payloads including `whatsapp_phone`

--- a/docs/ORDERS_FLOW_AUDIT.md
+++ b/docs/ORDERS_FLOW_AUDIT.md
@@ -153,7 +153,7 @@ Mapped errors:
 
 ### List / get
 
-- Cursor pagination (`created_on ASC, id_order ASC`).
+- Cursor pagination (`created_on DESC, id_order DESC` — newest first).
 - Filters: `ignore_status`, `status`, `id_user`, `q` (user name/email; numeric also matches `id_order`).
 - Default list hides `deleted`.
 - Joins items; returns snapshots as `name` / `unit_price`.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -27,7 +27,7 @@ info:
 
     **Productos:** cursor opaco **versión 1**, keyset sobre `id_product` descendente. Solo aplica al listado de productos.
 
-    **Órdenes:** cursor opaco **versión 2**, keyset sobre `(created_on ASC, id_order ASC)`. **No** es intercambiable con el de productos.
+    **Órdenes:** cursor opaco **versión 3**, keyset sobre `(created_on DESC, id_order DESC)` (más recientes primero). **No** es intercambiable con el de productos ni con cursores v2.
 
     El cliente debe tratar `cursor` y `next_cursor` como **cadenas opacas** (p. ej. Base64-URL); no dependas de su estructura interna.
 
@@ -205,7 +205,7 @@ paths:
       summary: Listar pedidos (admin)
       description: |
         Requiere **Bearer JWT** de **admin o superadmin**, tenant operable en contexto, y suscripción no `canceled`.
-        Orden: **`created_on` ascendente**, desempate **`id_order` ascendente** (más antiguos primero).
+        Orden: **`created_on` descendente**, desempate **`id_order` descendente** (más recientes primero).
 
         ### Transiciones de estado (PATCH)
         Lineales: `pending → preparing → ready → delivered`.
@@ -434,7 +434,7 @@ components:
     CursorOrders:
       name: cursor
       in: query
-      description: Cursor opaco (órdenes, v2). Omitir en la primera página. **No** usar el cursor de productos.
+      description: Cursor opaco (órdenes, v3). Omitir en la primera página. **No** usar el cursor de productos ni cursores v2.
       schema:
         type: string
     QueryQ:

--- a/internal/handlers/orders.go
+++ b/internal/handlers/orders.go
@@ -37,7 +37,8 @@ type ordersListResponse struct {
 	NextCursor *string                `json:"next_cursor"`
 }
 
-// GetAllOrders lists orders with cursor pagination (query: limit, cursor, optional id_user) and filters ignore_status, status.
+// GetAllOrders lists orders newest-first with cursor pagination (query: limit, cursor, optional id_user)
+// and filters ignore_status, status, q.
 // id_user: positive integer filters orders for that user within the tenant; omit for all users.
 func (h *OrderHandler) GetAllOrders(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/internal/pagination/order_cursor.go
+++ b/internal/pagination/order_cursor.go
@@ -8,7 +8,9 @@ import (
 	"time"
 )
 
-const orderCursorVersion = 2
+// orderCursorVersion 3: list is created_on DESC, id_order DESC (newest first).
+// Version 2 (ASC) cursors are rejected.
+const orderCursorVersion = 3
 
 type orderCursorPayload struct {
 	V  int    `json:"v"`
@@ -16,13 +18,13 @@ type orderCursorPayload struct {
 	TS string `json:"ts"` // RFC3339Nano, UTC
 }
 
-// OrderKeyset marks a position in the orders list ordered by created_on ASC, id_order ASC.
+// OrderKeyset marks a position in the orders list ordered by created_on DESC, id_order DESC.
 type OrderKeyset struct {
 	CreatedOn time.Time
 	ID        uint64
 }
 
-// EncodeOrderCursor builds the opaque cursor for the last visible order on a page (creation order).
+// EncodeOrderCursor builds the opaque cursor for the last visible order on a page (newest-first).
 func EncodeOrderCursor(createdOn time.Time, id uint64) (string, error) {
 	if id == 0 {
 		return "", errors.New("pagination: invalid order cursor id")
@@ -36,7 +38,7 @@ func EncodeOrderCursor(createdOn time.Time, id uint64) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// DecodeOrderCursor parses a cursor from EncodeOrderCursor (version 2 only).
+// DecodeOrderCursor parses a cursor from EncodeOrderCursor (version 3 only).
 func DecodeOrderCursor(s string) (OrderKeyset, error) {
 	var zero OrderKeyset
 	if s == "" {

--- a/internal/pagination/order_cursor_test.go
+++ b/internal/pagination/order_cursor_test.go
@@ -1,6 +1,7 @@
 package pagination
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -24,4 +25,13 @@ func TestDecodeOrderCursor_WrongVersion(t *testing.T) {
 	require.NoError(t, err)
 	_, err = DecodeOrderCursor(s)
 	assert.Error(t, err)
+}
+
+func TestDecodeOrderCursor_RejectsLegacyV2(t *testing.T) {
+	// Hand-built v2 payload (ASC era); must not decode under newest-first (v3).
+	raw := []byte(`{"v":2,"id":2,"ts":"2025-04-14T10:00:00.123456789Z"}`)
+	s := base64.RawURLEncoding.EncodeToString(raw)
+	_, err := DecodeOrderCursor(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported order cursor version")
 }

--- a/internal/repository/orders/order.go
+++ b/internal/repository/orders/order.go
@@ -103,14 +103,14 @@ func (r *OrderRepository) GetOrdersWithFilters(
 	return ordersFromJoinRows(rows, orderJoinSortIDAsc)
 }
 
-// ListOrdersPageResult is one page of orders (cursor on created_on ASC, id_order ASC).
+// ListOrdersPageResult is one page of orders (cursor on created_on DESC, id_order DESC).
 type ListOrdersPageResult struct {
 	Items      []oModel.OrderResponse
 	NextCursor *string
 }
 
 // ListOrdersWithFiltersPage returns orders for the tenant with the same status semantics as GetOrdersWithFilters,
-// ordered by creation time ascending (then id_order), paginated with an opaque cursor (see pagination.OrderKeyset).
+// ordered by creation time descending (then id_order), paginated with an opaque cursor (see pagination.OrderKeyset).
 func (r *OrderRepository) ListOrdersWithFiltersPage(
 	ctx context.Context,
 	tenantID uint64,
@@ -178,7 +178,7 @@ func (r *OrderRepository) ListOrdersWithFiltersPage(
         LEFT JOIN users u ON o.id_user = u.id_user
         INNER JOIN order_items oi ON o.id_order = oi.id_order
         WHERE o.tenant_id = $1 AND o.id_order = ANY($2::bigint[])
-        ORDER BY o.created_on ASC, o.id_order ASC, oi.id_order_item ASC
+        ORDER BY o.created_on DESC, o.id_order DESC, oi.id_order_item ASC
 	`
 	rows, err := r.DB.QueryContext(ctx, detailQuery, tenantID, pq.Array(ids))
 	if err != nil {
@@ -186,7 +186,7 @@ func (r *OrderRepository) ListOrdersWithFiltersPage(
 	}
 	defer rows.Close()
 
-	orders, err := ordersFromJoinRows(rows, orderJoinSortCreatedOnAscIDAsc)
+	orders, err := ordersFromJoinRows(rows, orderJoinSortCreatedOnDescIDDesc)
 	if err != nil {
 		return ListOrdersPageResult{}, err
 	}
@@ -239,11 +239,12 @@ func buildOrderIDPageQuery(tenantID uint64, ignoreStatus bool, statusFilter *str
 	if after != nil {
 		tArg := idx
 		idArg := idx + 1
-		q += fmt.Sprintf(" AND (o.created_on > $%d OR (o.created_on = $%d AND o.id_order > $%d))", tArg, tArg, idArg)
+		// Newest-first: next page is strictly older than the cursor keyset.
+		q += fmt.Sprintf(" AND (o.created_on < $%d OR (o.created_on = $%d AND o.id_order < $%d))", tArg, tArg, idArg)
 		args = append(args, after.CreatedOn, after.ID)
 		idx += 2
 	}
-	q += fmt.Sprintf(" ORDER BY o.created_on ASC, o.id_order ASC LIMIT $%d", idx)
+	q += fmt.Sprintf(" ORDER BY o.created_on DESC, o.id_order DESC LIMIT $%d", idx)
 	args = append(args, limit)
 	return q, args
 }
@@ -253,7 +254,7 @@ type orderJoinSort int
 const (
 	orderJoinSortIDAsc orderJoinSort = iota
 	orderJoinSortIDDesc
-	orderJoinSortCreatedOnAscIDAsc
+	orderJoinSortCreatedOnDescIDDesc
 )
 
 func ordersFromJoinRows(rows *sql.Rows, sortMode orderJoinSort) ([]oModel.OrderResponse, error) {
@@ -362,16 +363,16 @@ func ordersFromJoinRows(rows *sql.Rows, sortMode orderJoinSort) ([]oModel.OrderR
 		sort.Slice(orders, func(i, j int) bool { return orders[i].ID < orders[j].ID })
 	case orderJoinSortIDDesc:
 		sort.Slice(orders, func(i, j int) bool { return orders[i].ID > orders[j].ID })
-	case orderJoinSortCreatedOnAscIDAsc:
+	case orderJoinSortCreatedOnDescIDDesc:
 		sort.SliceStable(orders, func(i, j int) bool {
 			a, b := orders[i], orders[j]
-			if a.CreatedOn.Before(b.CreatedOn) {
+			if a.CreatedOn.After(b.CreatedOn) {
 				return true
 			}
-			if b.CreatedOn.Before(a.CreatedOn) {
+			if b.CreatedOn.After(a.CreatedOn) {
 				return false
 			}
-			return a.ID < b.ID
+			return a.ID > b.ID
 		})
 	default:
 		sort.Slice(orders, func(i, j int) bool { return orders[i].ID < orders[j].ID })

--- a/internal/repository/orders/order_test.go
+++ b/internal/repository/orders/order_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/radamesvaz/bakery-app/internal/errors"
+	"github.com/radamesvaz/bakery-app/internal/pagination"
 	oModel "github.com/radamesvaz/bakery-app/model/orders"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -848,11 +849,26 @@ func TestOrderRepository_BuildOrderIDPageQuery_WithSearch(t *testing.T) {
 	assert.True(t, strings.Contains(q, "EXISTS (SELECT 1 FROM users u"))
 	assert.True(t, strings.Contains(q, "u.name ILIKE"))
 	assert.True(t, strings.Contains(q, "u.email ILIKE"))
-	assert.True(t, strings.Contains(q, "ORDER BY o.created_on ASC, o.id_order ASC"))
+	assert.True(t, strings.Contains(q, "ORDER BY o.created_on DESC, o.id_order DESC"))
 	require.Len(t, args, 3)
 	assert.Equal(t, uint64(1), args[0])
 	assert.Equal(t, "%client%", args[1])
 	assert.Equal(t, 21, args[2])
+}
+
+func TestOrderRepository_BuildOrderIDPageQuery_WithCursorNewestFirst(t *testing.T) {
+	after := &pagination.OrderKeyset{
+		CreatedOn: time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC),
+		ID:        9,
+	}
+	q, args := buildOrderIDPageQuery(1, false, nil, after, nil, nil, 21)
+	assert.True(t, strings.Contains(q, "o.created_on <"))
+	assert.True(t, strings.Contains(q, "o.id_order <"))
+	assert.True(t, strings.Contains(q, "ORDER BY o.created_on DESC, o.id_order DESC"))
+	require.Len(t, args, 4)
+	assert.Equal(t, after.CreatedOn, args[1])
+	assert.Equal(t, after.ID, args[2])
+	assert.Equal(t, 21, args[3])
 }
 
 func TestOrderRepository_BuildOrderIDPageQuery_WithNumericSearch(t *testing.T) {

--- a/tests/orders_test.go
+++ b/tests/orders_test.go
@@ -1217,7 +1217,8 @@ func TestGetAllOrders_OrderByCreatedOnAndCursor(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &firstPage))
 	require.Len(t, firstPage.Items, 2)
 	require.NotNil(t, firstPage.NextCursor)
-	assert.True(t, !firstPage.Items[1].CreatedOn.Before(firstPage.Items[0].CreatedOn))
+	// Newest first within the page.
+	assert.True(t, !firstPage.Items[1].CreatedOn.After(firstPage.Items[0].CreatedOn))
 
 	req = httptest.NewRequest("GET", "/auth/orders?limit=2&cursor="+*firstPage.NextCursor, nil)
 	req.Header.Set("Authorization", "Bearer "+jwt)
@@ -1231,9 +1232,10 @@ func TestGetAllOrders_OrderByCreatedOnAndCursor(t *testing.T) {
 
 	lastFirst := firstPage.Items[len(firstPage.Items)-1]
 	firstSecond := secondPage.Items[0]
-	assert.True(t, firstSecond.CreatedOn.After(lastFirst.CreatedOn) || firstSecond.CreatedOn.Equal(lastFirst.CreatedOn))
+	// Next page continues with older orders.
+	assert.True(t, firstSecond.CreatedOn.Before(lastFirst.CreatedOn) || firstSecond.CreatedOn.Equal(lastFirst.CreatedOn))
 	if firstSecond.CreatedOn.Equal(lastFirst.CreatedOn) {
-		assert.Greater(t, firstSecond.ID, lastFirst.ID)
+		assert.Less(t, firstSecond.ID, lastFirst.ID)
 	}
 }
 
@@ -1389,12 +1391,12 @@ func TestGetAllOrders_SearchAndUserFilter_MultiPageCursorContinuity(t *testing.T
 	assert.NotZero(t, page2.Items[0].ID)
 	assert.NotEqual(t, page1.Items[0].ID, page2.Items[0].ID)
 
-	// Continuity and ordering across pages.
+	// Continuity and ordering across pages (newest first → older on next page).
 	lastPage1 := page1.Items[len(page1.Items)-1]
 	firstPage2 := page2.Items[0]
-	assert.True(t, firstPage2.CreatedOn.After(lastPage1.CreatedOn) || firstPage2.CreatedOn.Equal(lastPage1.CreatedOn))
+	assert.True(t, firstPage2.CreatedOn.Before(lastPage1.CreatedOn) || firstPage2.CreatedOn.Equal(lastPage1.CreatedOn))
 	if firstPage2.CreatedOn.Equal(lastPage1.CreatedOn) {
-		assert.Greater(t, firstPage2.ID, lastPage1.ID)
+		assert.Less(t, firstPage2.ID, lastPage1.ID)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default admin list ordering and breaks stored order cursors (v2), so frontends and integrations must refetch; pagination logic is well-tested but is a visible API contract shift.
> 
> **Overview**
> **`GET /auth/orders`** now returns orders **newest first** (`created_on DESC`, `id_order DESC`), including filtered/search paginated lists. Keyset pagination and in-memory ordering in the orders repository were flipped from ascending to descending; the next page loads **older** rows via `created_on` / `id_order` **less than** the cursor.
> 
> Order list cursors are **version 3**. **v2** (oldest-first) cursors are rejected at decode → **400** `Invalid cursor`. Clients must drop cached `next_cursor` and refetch from page one.
> 
> **Docs:** `CHANGELOG`, OpenAPI (`CursorOrders` v3), `FRONTEND_ORDERS_API_CHANGES` (section 4b + checklist), and `ORDERS_FLOW_AUDIT` updated for the new sort. Tests cover v2 rejection, query predicates, and multi-page continuity under newest-first.
> 
> The diff also adds **`docs/FRONTEND_TENANT_WHATSAPP_API_CHANGES.md`** (storefront/admin WhatsApp field guidance)—documentation only, no order-list code changes for that topic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82f0ea5dfe0deac1759ed4e6edc7d964364979f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->